### PR TITLE
DEPLOYMENT_DIR and minor improvements

### DIFF
--- a/release/kernel/Dockerfile
+++ b/release/kernel/Dockerfile
@@ -25,7 +25,9 @@ RUN mkdir /logs \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config
 
-# Configure WebSphere Liberty
+ENV DEPLOYMENT_DIR /config/dropins/
+
+# Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
     && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
 COPY docker-server /opt/ol/docker/

--- a/release/microProfile1/README.md
+++ b/release/microProfile1/README.md
@@ -1,6 +1,6 @@
 # Open Liberty image for Docker
 
-The [Dockerfile](Dockerfile) in this directory is used to build the `open-liberty:microProfile1` image on [Docker Hub](https://registry.hub.docker.com/_/open-liberty/). The image contains Open Liberty with Micro Profile features and an IBM Java Runtime Environment V8.
+The [Dockerfile](Dockerfile) in this directory is used to build the `open-liberty:microProfile1` image on [Docker Hub](https://registry.hub.docker.com/_/open-liberty/). The image contains Open Liberty with Micro Profile 1.0 features and an IBM Java Runtime Environment V8.
 
 # Usage
 

--- a/release/webProfile7/README.md
+++ b/release/webProfile7/README.md
@@ -1,6 +1,6 @@
 # Open Liberty image for Docker
 
-The [Dockerfile](Dockerfile) in this directory is used to build the `open-liberty:webProfile7` image on [Docker Hub](https://registry.hub.docker.com/_/open-liberty/). The image contains Open Liberty with Java EE Web Profile features and an IBM Java Runtime Environment V8.
+The [Dockerfile](Dockerfile) in this directory is used to build the `open-liberty:webProfile7` image on [Docker Hub](https://registry.hub.docker.com/_/open-liberty/). The image contains Open Liberty with Java EE Web Profile 7 features and an IBM Java Runtime Environment V8.
 
 # Usage
 


### PR DESCRIPTION
I would like to suggest the environment variable `DEPLOYMENT_DIR` pointing to `config/dropins` as it easily sticks out in the Dockerfile. Users building their own images can reference it like this:

    FROM openliberty/kernel
    COPY myapp.war ${DEPLOYMENT_DIR}

One could argue that there is already a soft link to `config/dropins`, yet I find that the variable improves readability.

Minor other improvements:

- Made version numbers explicit (e.g. Micro Profile 1.0 instead of 1, having 1.2 in mind)
- Renamed *WebSphere Liberty* in comments to *Open Liberty*