### PR TITLE
Add tags for EE8 support

### DIFF
--- a/release/javaee8/Dockerfile
+++ b/release/javaee8/Dockerfile
@@ -1,0 +1,5 @@
+FROM openliberty/open-liberty:kernel
+ENV KEYSTORE_REQUIRED "true"
+
+COPY server.xml /config/
+

--- a/release/javaee8/java8/ibmjava/Dockerfile
+++ b/release/javaee8/java8/ibmjava/Dockerfile
@@ -1,0 +1,6 @@
+FROM open-liberty:kernel-java8-ibm
+ENV KEYSTORE_REQUIRED "true"
+
+RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
+
+RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging

--- a/release/javaee8/java8/ibmsfj/Dockerfile
+++ b/release/javaee8/java8/ibmsfj/Dockerfile
@@ -1,0 +1,6 @@
+FROM open-liberty:kernel-java8-ibmsfj
+ENV KEYSTORE_REQUIRED "true"
+
+RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
+
+RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging

--- a/release/javaee8/java8/openj9/Dockerfile
+++ b/release/javaee8/java8/openj9/Dockerfile
@@ -1,0 +1,5 @@
+FROM open-liberty:kernel-java8-openj9
+ENV KEYSTORE_REQUIRED "true"
+
+RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
+

--- a/release/javaee8/server.xml
+++ b/release/javaee8/server.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>javaee-8.0</feature>
+    </featureManager>
+
+    <!-- This template enables security. To get the full use of all the capabilities, a keystore and user registry are required. -->
+    
+    <!-- For the keystore, default keys are generated and stored in a keystore. To provide the keystore password, generate an 
+         encoded password using bin/securityUtility encode and add it below in the password attribute of the keyStore element. 
+         Then uncomment the keyStore element. -->
+    <!--
+    <keyStore password=""/> 
+    -->
+    
+    <!--For a user registry configuration, configure your user registry. For example, configure a basic user registry using the
+        basicRegistry element. Specify your own user name below in the name attribute of the user element. For the password, 
+        generate an encoded password using bin/securityUtility encode and add it in the password attribute of the user element. 
+        Then uncomment the user element. -->
+    <basicRegistry id="basic" realm="BasicRealm"> 
+        <!-- <user name="yourUserName" password="" />  --> 
+    </basicRegistry>
+    
+    <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="9080"
+                  httpsPort="9443" />
+                  
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
+
+</server>

--- a/release/kernel/README.md
+++ b/release/kernel/README.md
@@ -13,7 +13,7 @@ FROM %%IMAGE%%:kernel
 COPY server.xml /config/
 ```
 
-The `microProfile1` image contains the features required to implement Eclipse MicroProfile 1.2. The `webProfile8` image contains the features required for Java EE8 Web Profile compliance. The `javaee8` image adds the features required for Java EE8 Full Platform compliance. The `webProfile7` image contains the features required for Java EE7 Web Profile compliance. The `javaee7` image adds the features required for Java EE7 Full Platform compliance. The `javaee8` image is also tagged with `latest`.
+The `microProfile1` image contains the features required to implement Eclipse MicroProfile 1.2. The `webProfile8` image contains the features required for Java EE8 Web Profile compliance. The `javaee8` image adds the features required for Java EE8 Full Platform compliance. The `javaee8` image is also tagged with `latest`. The `webProfile7` image contains the features required for Java EE7 Web Profile compliance. The `javaee7` image adds the features required for Java EE7 Full Platform compliance.
 
 There are also additional images for different JVM combinations. Currently there are tags for java8 only, but there are two variants one based on IBM Java and Ubuntu and the other based on the IBM small footprint Java which is based on alpine linux. The naming structure for the variants is tag-javaversion-vandor/variant. This leads to webProfile8-java8-ibmsfj as one. At this time the full list of images are:
 
@@ -45,7 +45,7 @@ The images are designed to support a number of different usage patterns. The fol
 	```console
 	$ docker run -d -p 80:9080 -p 443:9443 \
 	    -v /tmp/DefaultServletEngine/dropins/Sample1.war:/config/dropins/Sample1.war \
-	    %%IMAGE%%:webProfile7
+	    %%IMAGE%%:webProfile8
 	```
 
 	When the server is started, you can browse to http://localhost/Sample1/SimpleServlet on the Docker host.
@@ -55,13 +55,13 @@ The images are designed to support a number of different usage patterns. The fol
 	```console
 	$ docker run -d -p 80:9080 \
 	  -v /tmp/DefaultServletEngine:/config \
-	  %%IMAGE%%:webProfile7
+	  %%IMAGE%%:webProfile8
 	```
 
 3.	You can also build an application layer on top of this image by using either the default server configuration or a new server configuration. In this example, we have copied the `Sample1.war` from `/tmp/DefaultServletEngine/dropins` to the same directory as the following Dockerfile.
 
 	```dockerfile
-	FROM %%IMAGE%%:webProfile7
+	FROM %%IMAGE%%:webProfile8
 	ADD Sample1.war /config/dropins/
 	```
 
@@ -77,7 +77,7 @@ The images are designed to support a number of different usage patterns. The fol
 	Build and run the data volume container:
 
 	```dockerfile
-	FROM %%IMAGE%%:webProfile7
+	FROM %%IMAGE%%:webProfile8
 	ADD DefaultServletEngine /config
 	```
 
@@ -91,12 +91,12 @@ The images are designed to support a number of different usage patterns. The fol
 
 	```console
 	$ docker run -d -p 80:9080 \
-	  --volumes-from app %%IMAGE%%:webProfile7
+	  --volumes-from app %%IMAGE%%:webProfile8
 	```
 
 # Providing your own keystore/truststore
 
-When an `open-liberty` image starts, it can generate a Liberty server XML snippet in `/config/configDropins/defaults/keystore.xml` that specifies a `keyStore` stanza with a generated password. This causes Open Liberty to generate a default keystore and truststore with a self-signed certificate when it starts. The `javaee7` and `javaee8` images do this automatically, but other images can request this by setting:
+When an `open-liberty` image starts, it can generate a Liberty server XML snippet in `/config/configDropins/defaults/keystore.xml` that specifies a `keyStore` stanza with a generated password. This causes Open Liberty to generate a default keystore and truststore with a self-signed certificate when it starts. The `javaee8` and `javaee7` images do this automatically, but other images can request this by setting:
 
 ```console
 ENV KEYSTORE_REQUIRED "true"
@@ -141,7 +141,7 @@ Liberty writes to two different directories when running: `/opt/ol/wlp//output` 
 ```console
 docker run -d -p 80:9080 -p 443:9443 \
     --tmpfs /opt/ol/wlp//output --tmpfs /logs -v /config --read-only \
-    %%IMAGE%%:javaee7
+    %%IMAGE%%:javaee8
 ```
 
 # Relationship between Open Liberty and WebSphere Liberty

--- a/release/kernel/README.md
+++ b/release/kernel/README.md
@@ -13,9 +13,9 @@ FROM %%IMAGE%%:kernel
 COPY server.xml /config/
 ```
 
-The `microProfile1` image contains the features required to implement Eclipse MicroProfile 1.2. The `webProfile7` image contains the features required for Java EE7 Web Profile compliance. The `javaee7` image adds the features required for Java EE7 Full Platform compliance. The `javaee7` image is also tagged with `latest`.
+The `microProfile1` image contains the features required to implement Eclipse MicroProfile 1.2. The `webProfile8` image contains the features required for Java EE8 Web Profile compliance. The `javaee8` image adds the features required for Java EE8 Full Platform compliance. The `webProfile7` image contains the features required for Java EE7 Web Profile compliance. The `javaee7` image adds the features required for Java EE7 Full Platform compliance. The `javaee8` image is also tagged with `latest`.
 
-There are also additional images for different JVM combinations. Currently there are tags for java8 only, but there are two variants one based on IBM Java and Ubuntu and the other based on the IBM small footprint Java which is based on alpine linux. The naming structure for the variants is tag-javaversion-vandor/variant. This leads to webProfile7-java8-ibmsfj as one. At this time the full list of images are:
+There are also additional images for different JVM combinations. Currently there are tags for java8 only, but there are two variants one based on IBM Java and Ubuntu and the other based on the IBM small footprint Java which is based on alpine linux. The naming structure for the variants is tag-javaversion-vandor/variant. This leads to webProfile8-java8-ibmsfj as one. At this time the full list of images are:
 
 	kernel
 	kernel-java8-ibm
@@ -26,9 +26,15 @@ There are also additional images for different JVM combinations. Currently there
 	webProfile7
 	webProfile7-java8-ibm
 	webProfile7-java8-ibmsfj
+	webProfile8
+	webProfile8-java8-ibm
+	webProfile8-java8-ibmsfj
 	javaee7
 	javaee7-java8-ibm
 	javaee7-java8-ibmsfj
+	javaee8
+	javaee8-java8-ibm
+	javaee8-java8-ibmsfj
 
 # Usage
 
@@ -90,7 +96,7 @@ The images are designed to support a number of different usage patterns. The fol
 
 # Providing your own keystore/truststore
 
-When an `open-liberty` image starts, it can generate a Liberty server XML snippet in `/config/configDropins/defaults/keystore.xml` that specifies a `keyStore` stanza with a generated password. This causes Open Liberty to generate a default keystore and truststore with a self-signed certificate when it starts. The `javaee7` image does this automatically, but other images can request this by setting:
+When an `open-liberty` image starts, it can generate a Liberty server XML snippet in `/config/configDropins/defaults/keystore.xml` that specifies a `keyStore` stanza with a generated password. This causes Open Liberty to generate a default keystore and truststore with a self-signed certificate when it starts. The `javaee7` and `javaee8` images do this automatically, but other images can request this by setting:
 
 ```console
 ENV KEYSTORE_REQUIRED "true"

--- a/release/webProfile8/Dockerfile
+++ b/release/webProfile8/Dockerfile
@@ -1,0 +1,4 @@
+FROM openliberty/open-liberty:kernel
+
+COPY server.xml /config/
+

--- a/release/webProfile8/java8/ibmjava/Dockerfile
+++ b/release/webProfile8/java8/ibmjava/Dockerfile
@@ -1,0 +1,5 @@
+FROM open-liberty:kernel-java8-ibm
+
+RUN cp /opt/ol/wlp/templates/servers/webProfile8/server.xml /config/server.xml
+
+RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/

--- a/release/webProfile8/java8/ibmsfj/Dockerfile
+++ b/release/webProfile8/java8/ibmsfj/Dockerfile
@@ -1,0 +1,5 @@
+FROM open-liberty:kernel-java8-ibmsfj
+
+RUN cp /opt/ol/wlp/templates/servers/webProfile8/server.xml /config/server.xml
+
+RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/

--- a/release/webProfile8/java8/openj9/Dockerfile
+++ b/release/webProfile8/java8/openj9/Dockerfile
@@ -1,0 +1,5 @@
+FROM open-liberty:kernel-java8-openj9
+ENV KEYSTORE_REQUIRED "true"
+
+RUN cp /opt/ol/wlp/templates/servers/webProfile8/server.xml /config/server.xml
+

--- a/release/webProfile8/server.xml
+++ b/release/webProfile8/server.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>webProfile-8.0</feature>
+    </featureManager>
+
+    <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="9080"
+                  httpsPort="9443" />
+                  
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
+
+</server>


### PR DESCRIPTION
- Add new tags javaee8 and webProfile8
- Update the kernel README accordingly

Note: These tags depend on Liberty version being updated to 18.0.0.2 