### PR TITLE
Add wget to alpine images

### DIFF
--- a/official/javaee8/java8/ibmsfj/Dockerfile
+++ b/official/javaee8/java8/ibmsfj/Dockerfile
@@ -7,7 +7,8 @@ ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliber
 COPY docker-server /opt/ol/docker/
 
 # Install Open Liberty
-RUN wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
+RUN apk add --no-cache wget \
+   && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
    && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
    && sha1sum -c /tmp/wlp.zip.sha1 \
    && unzip -q /tmp/wlp.zip -d /opt/ol \

--- a/official/kernel/java8/ibmsfj/Dockerfile
+++ b/official/kernel/java8/ibmsfj/Dockerfile
@@ -8,7 +8,8 @@ LABEL maintainer="Alasdair Nottingham" vendor="Open Liberty" url="https://openli
 COPY docker-server /opt/ol/docker/
 
 # Install Open Liberty
-RUN wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
+RUN apk add --no-cache wget \
+   && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
    && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
    && sha1sum -c /tmp/wlp.zip.sha1 \
    && unzip -q /tmp/wlp.zip -d /opt/ol \

--- a/official/webProfile8/java8/ibmsfj/Dockerfile
+++ b/official/webProfile8/java8/ibmsfj/Dockerfile
@@ -7,7 +7,8 @@ ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliber
 COPY docker-server /opt/ol/docker/
 
 # Install Open Liberty
-RUN wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
+RUN apk add --no-cache wget \
+   && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
    && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
    && sha1sum -c /tmp/wlp.zip.sha1 \
    && unzip -q /tmp/wlp.zip -d /opt/ol \


### PR DESCRIPTION
When building images from the development drivers on DHE, we were getting sslv3 errors on the wget commands in these Dockerfiles.  The problem is with the default wget on alpine (BusyBox v1.27.2), but if we run `apk add wget`, we then can use GNU wget which handles the download properly.