### PR TITLE
Add support for a third image name in build scripts

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -3,7 +3,7 @@
 # Builds a single Open Liberty Docker Image
 #  dir and tag must be specified, other arguments allow for overrides in development builds.
 
-usage="Usage: build.sh --dir=<Dockerfile directory> --tag=<image tag name> (--tag2=<second image tag name> --version <product version> --imageSha=<image sha> --imageUrl=<image download url>)"
+usage="Usage: build.sh --dir=<Dockerfile directory> --tag=<image tag name> (--tag2=<second image tag name> --tag3=<third image tag name> --version <product version> --imageSha=<image sha> --imageUrl=<image download url>)"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -15,6 +15,9 @@ while [ $# -gt 0 ]; do
       ;;
     --tag2=*)
       tag2="${1#*=}"
+      ;;
+    --tag3=*)
+      tag3="${1#*=}"
       ;;
     --version=*)
       version="${1#*=}"
@@ -45,6 +48,10 @@ if [ ! -z "$tag2" ]
 then
   buildCommand="$buildCommand -t $tag2"
 fi
+if [ ! -z "$tag3" ]
+then
+  buildCommand="$buildCommand -t $tag3"
+fi
 if [ ! -z "$version" ]
 then
   buildCommand="$buildCommand --build-arg LIBERTY_VERSION=${version}"
@@ -62,7 +69,7 @@ repository="${tag%:*}"
 buildCommand="$buildCommand --build-arg REPOSITORY=${repository} $dir"
 
 echo "****"
-echo "Building $dir ($tag $tag2)"
+echo "Building $dir ($tag $tag2 $tag3)"
 echo "$buildCommand"
 echo "****"
 eval $buildCommand
@@ -70,9 +77,9 @@ eval $buildCommand
 if [ $? = 0 ]
 then
   echo "****"
-  echo "Build successful $dir ($tag $tag2)"
+  echo "Build successful $dir ($tag $tag2 $tag3)"
   echo "****"
 else
-  echo "Build failed $dir ($tag $tag2), exiting."
+  echo "Build failed $dir ($tag $tag2 $tag3), exiting."
   exit 1
 fi

--- a/build/buildAll.sh
+++ b/build/buildAll.sh
@@ -55,7 +55,7 @@ webprofile8DownloadSha=$(sha1sum webprofile8.zip | awk '{print $1;}')
 rm -f webprofile8.zip
 
 # Builds up the build.sh call to build each individual docker image listed in images.txt
-while read -r buildContextDirectory imageTag imageTag2
+while read -r buildContextDirectory imageTag imageTag2 imageTag3
 do
   buildCommand="./build.sh --dir=$buildContextDirectory --version=$version"
 
@@ -69,6 +69,10 @@ do
   if [ ! -z "$imageTag2" ]
   then
     buildCommand="$buildCommand --tag2=$repository:$imageTag2"
+  fi
+  if [ ! -z "$imageTag3" ]
+  then
+    buildCommand="$buildCommand --tag3=$repository:$imageTag3"
   fi
 
   if [[ $imageTag =~ javaee8 ]]

--- a/build/images.txt
+++ b/build/images.txt
@@ -11,7 +11,7 @@
 ../official/kernel/java8/ibmsfj         kernel-java8-ibmsfj
 ../official/javaee7/java8/ibmjava       javaee7-java8-ibm          javaee7
 ../official/javaee7/java8/ibmsfj        javaee7-java8-ibmsfj
-../official/javaee8/java8/ibmjava       javaee8-java8-ibm          javaee8
+../official/javaee8/java8/ibmjava       javaee8-java8-ibm          javaee8       latest
 ../official/javaee8/java8/ibmsfj        javaee8-java8-ibmsfj
 ../official/microProfile1/java8/ibmjava microProfile1-java8-ibm    microProfile1
 ../official/microProfile1/java8/ibmsfj  microProfile1-java8-ibmsfj


### PR DESCRIPTION
Simple change adding support for a third image tag name in the build scripts, and adding the `latest` tag to the `javaee8` image.