### PR TITLE
Move lib.index.cache directory work to springBoot files

### DIFF
--- a/community/javaee8/java11/openj9/Dockerfile
+++ b/community/javaee8/java11/openj9/Dockerfile
@@ -40,7 +40,6 @@ ENV RANDFILE=/tmp/.rnd \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -60,8 +59,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
 

--- a/community/javaee8/java8/openj9/Dockerfile
+++ b/community/javaee8/java8/openj9/Dockerfile
@@ -40,7 +40,6 @@ ENV RANDFILE=/tmp/.rnd \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -60,8 +59,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
 

--- a/community/kernel/java11/openj9/Dockerfile
+++ b/community/kernel/java11/openj9/Dockerfile
@@ -37,7 +37,6 @@ RUN /opt/ol/wlp/bin/server create \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -57,8 +56,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 

--- a/community/kernel/java8/openj9/Dockerfile
+++ b/community/kernel/java8/openj9/Dockerfile
@@ -37,7 +37,6 @@ RUN /opt/ol/wlp/bin/server create \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -57,8 +56,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 

--- a/community/springBoot1/java11/openj9/Dockerfile
+++ b/community/springBoot1/java11/openj9/Dockerfile
@@ -1,6 +1,8 @@
 FROM openliberty/open-liberty:kernel-java11-openj9
 
 RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ol/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache
 
 RUN cp /opt/ol/wlp/templates/servers/springBoot1/server.xml /config/server.xml

--- a/community/springBoot1/java8/openj9/Dockerfile
+++ b/community/springBoot1/java8/openj9/Dockerfile
@@ -1,6 +1,8 @@
 FROM openliberty/open-liberty:kernel-java8-openj9
 
 RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ol/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache
 
 RUN cp /opt/ol/wlp/templates/servers/springBoot1/server.xml /config/server.xml

--- a/community/springBoot2/java11/openj9/Dockerfile
+++ b/community/springBoot2/java11/openj9/Dockerfile
@@ -1,6 +1,8 @@
 FROM openliberty/open-liberty:kernel-java11-openj9
 
 RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ol/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache
 
 RUN cp /opt/ol/wlp/templates/servers/springBoot2/server.xml /config/server.xml

--- a/community/springBoot2/java8/openj9/Dockerfile
+++ b/community/springBoot2/java8/openj9/Dockerfile
@@ -1,7 +1,10 @@
 FROM openliberty/open-liberty:kernel-java8-openj9
 
 RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ol/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache
+
 
 RUN cp /opt/ol/wlp/templates/servers/springBoot2/server.xml /config/server.xml
 

--- a/community/webProfile8/java11/openj9/Dockerfile
+++ b/community/webProfile8/java11/openj9/Dockerfile
@@ -41,7 +41,6 @@ ENV RANDFILE=/tmp/.rnd \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -61,8 +60,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
 

--- a/community/webProfile8/java8/openj9/Dockerfile
+++ b/community/webProfile8/java8/openj9/Dockerfile
@@ -41,7 +41,6 @@ ENV RANDFILE=/tmp/.rnd \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -61,8 +60,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
 

--- a/official/javaee8/java8/ibmjava/Dockerfile
+++ b/official/javaee8/java8/ibmjava/Dockerfile
@@ -41,7 +41,6 @@ ENV RANDFILE=/tmp/.rnd \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -61,8 +60,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
 

--- a/official/javaee8/java8/ibmsfj/Dockerfile
+++ b/official/javaee8/java8/ibmsfj/Dockerfile
@@ -36,7 +36,6 @@ ENV RANDFILE=/tmp/.rnd \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -56,8 +55,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
 

--- a/official/kernel/java8/ibmjava/Dockerfile
+++ b/official/kernel/java8/ibmjava/Dockerfile
@@ -36,7 +36,6 @@ RUN /opt/ol/wlp/bin/server create \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -56,8 +55,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 

--- a/official/kernel/java8/ibmsfj/Dockerfile
+++ b/official/kernel/java8/ibmsfj/Dockerfile
@@ -32,7 +32,6 @@ RUN /opt/ol/wlp/bin/server create \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -52,8 +51,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 

--- a/official/springBoot1/java8/ibmjava/Dockerfile
+++ b/official/springBoot1/java8/ibmjava/Dockerfile
@@ -1,6 +1,8 @@
 FROM open-liberty:kernel-java8-ibm
 
 RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ol/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache
 
 RUN cp /opt/ol/wlp/templates/servers/springBoot1/server.xml /config/server.xml

--- a/official/springBoot1/java8/ibmsfj/Dockerfile
+++ b/official/springBoot1/java8/ibmsfj/Dockerfile
@@ -1,6 +1,8 @@
 FROM open-liberty:kernel-java8-ibmsfj
 
 RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ol/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache
 
 RUN cp /opt/ol/wlp/templates/servers/springBoot1/server.xml /config/server.xml

--- a/official/springBoot2/java8/ibmjava/Dockerfile
+++ b/official/springBoot2/java8/ibmjava/Dockerfile
@@ -1,6 +1,8 @@
 FROM open-liberty:kernel-java8-ibm
 
 RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ol/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache
 
 RUN cp /opt/ol/wlp/templates/servers/springBoot2/server.xml /config/server.xml

--- a/official/springBoot2/java8/ibmsfj/Dockerfile
+++ b/official/springBoot2/java8/ibmsfj/Dockerfile
@@ -1,6 +1,8 @@
 FROM open-liberty:kernel-java8-ibmsfj
 
 RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ol/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache
 
 RUN cp /opt/ol/wlp/templates/servers/springBoot2/server.xml /config/server.xml

--- a/official/webProfile8/java8/ibmjava/Dockerfile
+++ b/official/webProfile8/java8/ibmjava/Dockerfile
@@ -40,7 +40,6 @@ ENV RANDFILE=/tmp/.rnd \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -60,8 +59,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
     

--- a/official/webProfile8/java8/ibmsfj/Dockerfile
+++ b/official/webProfile8/java8/ibmsfj/Dockerfile
@@ -36,7 +36,6 @@ ENV RANDFILE=/tmp/.rnd \
 
 # Create symlinks && set permissions for non-root user    
 RUN mkdir /logs \
-    && mkdir /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
@@ -56,8 +55,6 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
 


### PR DESCRIPTION
@tjwatson and @anjumfatima90 pointed out that there is a problem with the kernel Dockerfile creating the /lib.index.cache directory when it should really be a symlink to /opt/ol/wlp/usr/shared/resources/lib.index.cache.

Since that directory is only used by the springBoot images, we are moving the work related to that directory into the springBoot Dockerfiles.