### PR TITLE
Add build label to OL images

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -3,7 +3,7 @@
 # Builds a single Open Liberty Docker Image
 #  dir and tag must be specified, other arguments allow for overrides in development builds.
 
-usage="Usage: build.sh --dir=<Dockerfile directory> --tag=<image tag name> (--tag2=<second image tag name> --tag3=<third image tag name> --version <product version> --imageSha=<image sha> --imageUrl=<image download url>)"
+usage="Usage: build.sh --dir=<Dockerfile directory> --tag=<image tag name> (--tag2=<second image tag name> --tag3=<third image tag name> --version <product version> --buildLabel <build label> --imageSha=<image sha> --imageUrl=<image download url>)"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -21,6 +21,9 @@ while [ $# -gt 0 ]; do
       ;;
     --version=*)
       version="${1#*=}"
+      ;;
+    --buildLabel=*)
+      buildLabel="${1#*=}"
       ;;
     --imageSha=*)
       imageSha="${1#*=}"
@@ -55,6 +58,10 @@ fi
 if [ ! -z "$version" ]
 then
   buildCommand="$buildCommand --build-arg LIBERTY_VERSION=${version}"
+fi
+if [ ! -z "$buildLabel" ]
+then
+  buildCommand="$buildCommand --build-arg LIBERTY_BUILD_LABEL=${buildLabel}"
 fi
 if [ ! -z "$imageSha" ]
 then

--- a/build/buildAll.sh
+++ b/build/buildAll.sh
@@ -3,9 +3,10 @@
 # Builds all Open Liberty Docker images
 #  values set below, or in arguments, will override the defaults set in the Dockerfiles, allowing for development builds
 
-usage="Usage (all args optional): buildAll.sh --version=<version> --communityRepository=<communityRepository> --officialRepository=<officialRepository> --javaee8DownloadUrl=<javaee8 image download url> --runtimeDownloadUrl=<runtime image download url> --webprofile8DownloadUrl=<webprofile8 image download url>"
+usage="Usage (all args optional): buildAll.sh --version=<version> --buildLabel=<build label> --communityRepository=<communityRepository> --officialRepository=<officialRepository> --javaee8DownloadUrl=<javaee8 image download url> --runtimeDownloadUrl=<runtime image download url> --webprofile8DownloadUrl=<webprofile8 image download url>"
 
 version=19.0.0.4
+buildLabel=cl190420190419-0642
 communityRepository=openliberty/open-liberty
 officialRepository=open-liberty
 javaee8DownloadUrl="https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/${version}/openliberty-javaee8-${version}.zip"
@@ -17,6 +18,9 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --version=*)
       version="${1#*=}"
+      ;;
+    --buildLabel=*)
+      buildLabel="${1#*=}"
       ;;
     --communityRepository=*)
       communityRepository="${1#*=}"
@@ -57,7 +61,7 @@ rm -f webprofile8.zip
 # Builds up the build.sh call to build each individual docker image listed in images.txt
 while read -r buildContextDirectory imageTag imageTag2 imageTag3
 do
-  buildCommand="./build.sh --dir=$buildContextDirectory --version=$version"
+  buildCommand="./build.sh --dir=$buildContextDirectory --version=$version --buildLabel=$buildLabel"
 
   if [[ $buildContextDirectory =~ community ]]
   then

--- a/community/javaee8/java11/openj9/Dockerfile
+++ b/community/javaee8/java11/openj9/Dockerfile
@@ -2,9 +2,11 @@
 FROM adoptopenjdk/openjdk11-openj9
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=657ddda1fc6013ba14dfda51e28834d7ca4a78fe
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/$LIBERTY_VERSION/openliberty-javaee8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/javaee8/java8/openj9/Dockerfile
+++ b/community/javaee8/java8/openj9/Dockerfile
@@ -2,9 +2,11 @@
 FROM adoptopenjdk/openjdk8-openj9
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=657ddda1fc6013ba14dfda51e28834d7ca4a78fe
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/$LIBERTY_VERSION/openliberty-javaee8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/kernel/java11/openj9/Dockerfile
+++ b/community/kernel/java11/openj9/Dockerfile
@@ -2,9 +2,11 @@
 FROM adoptopenjdk/openjdk11-openj9
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=d4a9be40d4e1e6e859b836f68379636eb2c19c6d
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/kernel/java8/openj9/Dockerfile
+++ b/community/kernel/java8/openj9/Dockerfile
@@ -2,9 +2,11 @@
 FROM adoptopenjdk/openjdk8-openj9
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=d4a9be40d4e1e6e859b836f68379636eb2c19c6d
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/webProfile8/java11/openj9/Dockerfile
+++ b/community/webProfile8/java11/openj9/Dockerfile
@@ -2,9 +2,11 @@
 FROM adoptopenjdk/openjdk11-openj9
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=64c39d499297823ff2b56f8a7108b57da3a13fc4
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/$LIBERTY_VERSION/openliberty-webProfile8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/webProfile8/java8/openj9/Dockerfile
+++ b/community/webProfile8/java8/openj9/Dockerfile
@@ -2,9 +2,11 @@
 FROM adoptopenjdk/openjdk8-openj9
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=64c39d499297823ff2b56f8a7108b57da3a13fc4
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/$LIBERTY_VERSION/openliberty-webProfile8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/javaee8/java8/ibmjava/Dockerfile
+++ b/official/javaee8/java8/ibmjava/Dockerfile
@@ -2,9 +2,11 @@
 FROM ibmjava:8-jre
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=657ddda1fc6013ba14dfda51e28834d7ca4a78fe
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/$LIBERTY_VERSION/openliberty-javaee8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/javaee8/java8/ibmsfj/Dockerfile
+++ b/official/javaee8/java8/ibmsfj/Dockerfile
@@ -2,9 +2,11 @@
 FROM ibmjava:8-sfj-alpine
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=657ddda1fc6013ba14dfda51e28834d7ca4a78fe
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/$LIBERTY_VERSION/openliberty-javaee8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/kernel/java8/ibmjava/Dockerfile
+++ b/official/kernel/java8/ibmjava/Dockerfile
@@ -1,9 +1,11 @@
 FROM ibmjava:8-jre
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=d4a9be40d4e1e6e859b836f68379636eb2c19c6d
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/kernel/java8/ibmsfj/Dockerfile
+++ b/official/kernel/java8/ibmsfj/Dockerfile
@@ -1,9 +1,11 @@
 FROM ibmjava:8-sfj-alpine
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=d4a9be40d4e1e6e859b836f68379636eb2c19c6d
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/webProfile8/java8/ibmjava/Dockerfile
+++ b/official/webProfile8/java8/ibmjava/Dockerfile
@@ -2,9 +2,11 @@
 FROM ibmjava:8-jre
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=64c39d499297823ff2b56f8a7108b57da3a13fc4
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/$LIBERTY_VERSION/openliberty-webProfile8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/webProfile8/java8/ibmsfj/Dockerfile
+++ b/official/webProfile8/java8/ibmsfj/Dockerfile
@@ -2,9 +2,11 @@
 FROM ibmjava:8-sfj-alpine
 ARG LIBERTY_VERSION=19.0.0.4
 ARG LIBERTY_SHA=64c39d499297823ff2b56f8a7108b57da3a13fc4
+ARG LIBERTY_BUILD_LABEL=cl190420190419-0642
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/$LIBERTY_VERSION/openliberty-webProfile8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 


### PR DESCRIPTION
Adding the production build label to the OL images, to allow mapping from the Docker image to the build that it was based on.