### PR TITLE
Fix incorrect path in hazelcast doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The Liberty session caching feature builds on top of an existing technology call
 ```dockerfile
 ### Hazelcast Session Caching ###
 # Copy the Hazelcast libraries from the Hazelcast Docker image
-COPY --from=hazelcast/hazelcast --chown=1001:0 /opt/hazelcast/lib/*.jar /opt/ibm/wlp/usr/shared/resources/hazelcast/
+COPY --from=hazelcast/hazelcast --chown=1001:0 /opt/hazelcast/lib/*.jar /opt/ol/wlp/usr/shared/resources/hazelcast/
 
 # Instruct configure.sh to copy the client topology hazelcast.xml
 ARG HZ_SESSION_CACHE=client


### PR DESCRIPTION
Fixing an incorrect path in the session caching doc.