### PR TITLE
Label and other fixes pointed out by Docker

### DIFF
--- a/common/helpers/build/configure.sh
+++ b/common/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/javaee8/java11/openj9/Dockerfile
+++ b/community/javaee8/java11/openj9/Dockerfile
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=180a2499f42f7469df06bbe39e27a5b0268113f8
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/$LIBERTY_VERSION/openliberty-javaee8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/javaee8/java11/openj9/helpers/build/configure.sh
+++ b/community/javaee8/java11/openj9/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/javaee8/java8/ibmsfj/Dockerfile.ubi-min
+++ b/community/javaee8/java8/ibmsfj/Dockerfile.ubi-min
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=180a2499f42f7469df06bbe39e27a5b0268113f8
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/$LIBERTY_VERSION/openliberty-javaee8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/javaee8/java8/openj9/Dockerfile
+++ b/community/javaee8/java8/openj9/Dockerfile
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=180a2499f42f7469df06bbe39e27a5b0268113f8
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/$LIBERTY_VERSION/openliberty-javaee8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/community/javaee8/java8/openj9/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/kernel/java11/openj9/Dockerfile
+++ b/community/kernel/java11/openj9/Dockerfile
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=ee0fdbc716e9431b73d483555f0e267f007f0286
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/kernel/java11/openj9/helpers/build/configure.sh
+++ b/community/kernel/java11/openj9/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/kernel/java8/ibmsfj/Dockerfile.ubi-min
+++ b/community/kernel/java8/ibmsfj/Dockerfile.ubi-min
@@ -4,8 +4,11 @@ ARG LIBERTY_SHA=ee0fdbc716e9431b73d483555f0e267f007f0286
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/kernel/java8/openj9/Dockerfile
+++ b/community/kernel/java8/openj9/Dockerfile
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=ee0fdbc716e9431b73d483555f0e267f007f0286
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/kernel/java8/openj9/helpers/build/configure.sh
+++ b/community/kernel/java8/openj9/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/webProfile8/java11/openj9/Dockerfile
+++ b/community/webProfile8/java11/openj9/Dockerfile
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=d0b7dfe4f5f2f4c7b6280081c123aab3fc90fdcc
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/$LIBERTY_VERSION/openliberty-webProfile8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/webProfile8/java11/openj9/helpers/build/configure.sh
+++ b/community/webProfile8/java11/openj9/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/webProfile8/java8/ibmsfj/Dockerfile.ubi-min
+++ b/community/webProfile8/java8/ibmsfj/Dockerfile.ubi-min
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=d0b7dfe4f5f2f4c7b6280081c123aab3fc90fdcc
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/$LIBERTY_VERSION/openliberty-webProfile8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/webProfile8/java8/openj9/Dockerfile
+++ b/community/webProfile8/java8/openj9/Dockerfile
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=d0b7dfe4f5f2f4c7b6280081c123aab3fc90fdcc
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/$LIBERTY_VERSION/openliberty-webProfile8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/community/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/community/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/javaee8/java8/ibmjava/Dockerfile
+++ b/official/javaee8/java8/ibmjava/Dockerfile
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=180a2499f42f7469df06bbe39e27a5b0268113f8
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/$LIBERTY_VERSION/openliberty-javaee8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/javaee8/java8/ibmsfj/Dockerfile
+++ b/official/javaee8/java8/ibmsfj/Dockerfile
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=180a2499f42f7469df06bbe39e27a5b0268113f8
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/$LIBERTY_VERSION/openliberty-javaee8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/kernel/java8/ibmjava/Dockerfile
+++ b/official/kernel/java8/ibmjava/Dockerfile
@@ -4,8 +4,11 @@ ARG LIBERTY_SHA=ee0fdbc716e9431b73d483555f0e267f007f0286
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/kernel/java8/ibmsfj/Dockerfile
+++ b/official/kernel/java8/ibmsfj/Dockerfile
@@ -4,13 +4,16 @@ ARG LIBERTY_SHA=ee0fdbc716e9431b73d483555f0e267f007f0286
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 
 # Install Open Liberty
-RUN apk --update add --no-cache wget openssl \
+RUN apk add --no-cache wget openssl \
     && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
     && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
     && sha1sum -c /tmp/wlp.zip.sha1 \

--- a/official/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/webProfile8/java8/ibmjava/Dockerfile
+++ b/official/webProfile8/java8/ibmjava/Dockerfile
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=d0b7dfe4f5f2f4c7b6280081c123aab3fc90fdcc
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/$LIBERTY_VERSION/openliberty-webProfile8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/webProfile8/java8/ibmsfj/Dockerfile
+++ b/official/webProfile8/java8/ibmsfj/Dockerfile
@@ -5,8 +5,11 @@ ARG LIBERTY_SHA=d0b7dfe4f5f2f4c7b6280081c123aab3fc90fdcc
 ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/$LIBERTY_VERSION/openliberty-webProfile8-$LIBERTY_VERSION.zip
 
-LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
-      BuildLabel="$LIBERTY_BUILD_LABEL"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
 
 COPY helpers /opt/ol/helpers
 

--- a/official/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -63,4 +63,4 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
   fi
 fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*


### PR DESCRIPTION
Fixing issues pointed out under https://github.com/docker-library/official-images/pull/5950

- Removing --update from the apk add --no-cache calls.
- Updating image labels to comply with https://github.com/opencontainers/image-spec/blob/v1.0.1/annotations.md
- Removing bad RUN in configure.sh server start/stop line.