### PR TITLE
Provide OpenJ9 Java 12 images

### DIFF
--- a/build/images.txt
+++ b/build/images.txt
@@ -2,6 +2,7 @@
 ../official/19.0.0.x/kernel/java8/ibmsfj         kernel-java8-ibmsfj
 ../official/19.0.0.x/kernel/java8/openj9         kernel-java8-openj9
 ../official/19.0.0.x/kernel/java11/openj9        kernel-java11
+../official/19.0.0.x/kernel/java12/openj9        kernel-java12
 ../official/19.0.0.x/javaee7/java8/ibmjava       javaee7-java8-ibm          javaee7
 ../official/19.0.0.x/javaee7/java8/ibmsfj        javaee7-java8-ibmsfj
 ../official/19.0.0.x/javaee7/java8/openj9        javaee7-java8-openj9
@@ -10,6 +11,7 @@
 ../official/19.0.0.x/javaee8/java8/ibmsfj        javaee8-java8-ibmsfj
 ../official/19.0.0.x/javaee8/java8/openj9        javaee8-java8-openj9
 ../official/19.0.0.x/javaee8/java11/openj9       javaee8-java11
+../official/19.0.0.x/javaee8/java12/openj9       javaee8-java12
 ../official/19.0.0.x/microProfile1/java8/ibmjava microProfile1-java8-ibm    microProfile1
 ../official/19.0.0.x/microProfile1/java8/ibmsfj  microProfile1-java8-ibmsfj
 ../official/19.0.0.x/microProfile1/java8/openj9  microProfile1-java8-openj9
@@ -18,6 +20,7 @@
 ../official/19.0.0.x/microProfile2/java8/ibmsfj  microProfile2-java8-ibmsfj
 ../official/19.0.0.x/microProfile2/java8/openj9  microProfile2-java8-openj9
 ../official/19.0.0.x/microProfile2/java11/openj9 microProfile2-java11
+../official/19.0.0.x/microProfile2/java12/openj9 microProfile2-java12
 ../official/19.0.0.x/springBoot1/java8/ibmjava   springBoot1-java8-ibm      springBoot1
 ../official/19.0.0.x/springBoot1/java8/ibmsfj    springBoot1-java8-ibmsfj
 ../official/19.0.0.x/springBoot1/java8/openj9    springBoot1-java8-openj9
@@ -26,6 +29,7 @@
 ../official/19.0.0.x/springBoot2/java8/ibmsfj    springBoot2-java8-ibmsfj
 ../official/19.0.0.x/springBoot2/java8/openj9    springBoot2-java8-openj9
 ../official/19.0.0.x/springBoot2/java11/openj9   springBoot2-java11
+../official/19.0.0.x/springBoot2/java12/openj9   springBoot2-java12
 ../official/19.0.0.x/webProfile7/java8/ibmjava   webProfile7-java8-ibm      webProfile7
 ../official/19.0.0.x/webProfile7/java8/ibmsfj    webProfile7-java8-ibmsfj
 ../official/19.0.0.x/webProfile7/java8/openj9    webProfile7-java8-openj9
@@ -34,6 +38,7 @@
 ../official/19.0.0.x/webProfile8/java8/ibmsfj    webProfile8-java8-ibmsfj
 ../official/19.0.0.x/webProfile8/java8/openj9    webProfile8-java8-openj9
 ../official/19.0.0.x/webProfile8/java11/openj9   webProfile8-java11
+../official/19.0.0.x/webProfile8/java12/openj9   webProfile8-java12
 ../official/19.0.0.3/kernel/java8/ibmjava        19.0.0.3-kernel-java8-ibm           19.0.0.3-kernel
 ../official/19.0.0.3/kernel/java8/ibmsfj         19.0.0.3-kernel-java8-ibmsfj
 ../official/19.0.0.3/kernel/java8/openj9         19.0.0.3-kernel-java8-openj9

--- a/official/19.0.0.x/javaee8/java12/openj9/Dockerfile
+++ b/official/19.0.0.x/javaee8/java12/openj9/Dockerfile
@@ -1,0 +1,85 @@
+FROM adoptopenjdk:12-jre-openj9
+ARG LIBERTY_VERSION=19.0.0.5
+ARG LIBERTY_SHA=180a2499f42f7469df06bbe39e27a5b0268113f8
+ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
+ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/$LIBERTY_VERSION/openliberty-javaee8-$LIBERTY_VERSION.zip
+
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
+
+COPY helpers /opt/ol/helpers
+
+# Install Open Liberty
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip openssl wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
+    && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
+    && sha1sum -c /tmp/wlp.zip.sha1 \
+    && unzip -q /tmp/wlp.zip -d /opt/ol \
+    && rm /tmp/wlp.zip \
+    && rm /tmp/wlp.zip.sha1 \
+    && apt-get remove -y unzip \
+    && apt-get remove -y wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
+    && chown -R 1001:0 /opt/ol/wlp \
+    && chmod -R g+rw /opt/ol/wlp
+
+# Set Path Shortcuts
+ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+    LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ol/wlp/output \
+    WLP_SKIP_MAXPERMSIZE=true
+
+# Configure Open Liberty
+RUN /opt/ol/wlp/bin/server create \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea 
+
+# These settings are needed so that we can run as a different user than 1001 after server warmup
+# TODO: Eventually convert this to OPENJ9_JAVA_OPTIONS once the Liberty server script honors it
+ENV RANDFILE=/tmp/.rnd \
+    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+
+# Temp workaround so that launcher script doesn't try to open up non-existatnt JDK-only modules
+COPY java9.options /opt/ol/wlp/lib/platform/java/
+
+# Create symlinks && set permissions for non-root user    
+RUN mkdir /logs \
+    && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && ln -s /opt/ol/wlp /liberty \
+    && chown -R 1001:0 /opt/ol/wlp/lib/platform/java/java9.options \
+    && chmod -R g+rw /opt/ol/wlp/lib/platform/java/java9.options \
+    && mkdir -p /home/default \
+    && chown -R 1001:0 /home/default \
+    && chmod -R g+rw /home/default \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /opt/ol/wlp/usr \
+    && chmod -R g+rw /opt/ol/wlp/usr \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rw /opt/ol/wlp/output \
+    && chown -R 1001:0 /opt/ol/helpers \
+    && chmod -R g+rw /opt/ol/helpers \
+    && mkdir /etc/wlp \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+
+USER 1001
+
+EXPOSE 9080 9443
+
+ENV KEYSTORE_REQUIRED true
+
+ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/hazelcast-client.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/hazelcast-client.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+  <network>
+    <redo-operation>true</redo-operation>
+    <discovery-strategies>
+      <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+      </discovery-strategy>
+    </discovery-strategies>
+  </network>
+</hazelcast-client>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/hazelcast-embedded.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/hazelcast-embedded.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+  <network>
+    <join>
+      <multicast enabled="false"/>
+      <tcp-ip enabled="false"/>
+      <discovery-strategies>
+        <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+        </discovery-strategy>
+      </discovery-strategies>
+    </join>
+  </network>
+</hazelcast>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/hazelcast-sessioncache.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/hazelcast-sessioncache.xml
@@ -1,0 +1,11 @@
+<server>
+  <featureManager>
+    <feature>sessionCache-1.0</feature>
+  </featureManager>
+  <httpSessionCache libraryRef="HazelcastLib">
+    <properties hazelcast.config.location="file:${shared.config.dir}/hazelcast/hazelcast.xml"/>
+  </httpSessionCache>
+  <library id="HazelcastLib">
+    <fileset dir="${shared.resource.dir}/hazelcast"/>
+  </library>
+</server>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/http-endpoint.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/http-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="9080" />
+</server>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/http-ssl-endpoint.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/http-ssl-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpsPort="9443" httpPort="9080" />
+</server>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/iiop-endpoint.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/iiop-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <iiopEndpoint id="defaultIiopEndpoint" host="${env.IIOP_ENDPOINT_HOST}" iiopPort="2809" />
+</server>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <iiopEndpoint id="defaultIiopEndpoint" host="${env.IIOP_ENDPOINT_HOST}" iiopPort="2809">
+        <iiopsOptions iiopsPort="9402" sslRef="defaultSSLConfig" />
+    </iiopEndpoint>
+</server>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/jms-endpoint.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/jms-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsPort="7276" />
+</server>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsSSLPort="7286" />
+</server>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/mp-health-check.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/mp-health-check.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>mpHealth-1.0</feature>
+    </featureManager>
+</server>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/mp-monitoring.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/mp-monitoring.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>mpMetrics-1.1</feature>
+        <feature>monitor-1.0</feature>
+    </featureManager>
+    
+    <mpMetrics authentication="false" />
+</server>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>ssl-1.0</feature>
+    </featureManager>
+</server>

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/build/configure.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -Eeox pipefail
+
+##Define variables for XML snippets source and target paths
+WLP_INSTALL_DIR=/opt/ol/wlp
+SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
+SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
+
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+mkdir -p ${SNIPPETS_TARGET}
+
+
+#Check for each Liberty value-add functionality
+
+# MicroProfile Health
+if [ "$MP_HEALTH_CHECK" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
+fi
+
+# MicroProfile Monitoring
+if [ "$MP_MONITORING" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
+fi
+
+# SSL
+if [ "$SSL" == "true" ]; then
+  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
+fi
+
+# HTTP Endpoint
+if [ "$HTTP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
+  fi
+fi
+
+# Hazelcast Session Caching
+if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]
+then
+ cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
+ mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
+ cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
+fi
+
+# IIOP Endpoint
+if [ "$IIOP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
+  fi
+fi
+
+# JMS Endpoint
+if [ "$JMS_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
+  fi
+fi
+# Server start/stop to populate the /output/workarea and make subsequent server starts faster
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.x/javaee8/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.x/javaee8/java12/openj9/helpers/runtime/docker-server.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+keystorePath="/config/configDropins/defaults/keystore.xml"
+
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
+  then
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export PASSWORD=$(openssl rand -base64 32)
+      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
+
+    # Create the keystore.xml file and place in configDropins
+    mkdir -p $(dirname $keystorePath)
+    echo $XML > $keystorePath
+    fi
+  fi
+fi
+
+# Pass on to the real server run
+exec "$@"

--- a/official/19.0.0.x/javaee8/java12/openj9/java9.options
+++ b/official/19.0.0.x/javaee8/java12/openj9/java9.options
@@ -1,0 +1,43 @@
+### Exports
+# for JMX VMSupport in LocalConnectorActivator
+--add-exports
+java.base/jdk.internal.vm=ALL-UNNAMED
+# for com.ibm.crypto.ibmkeycert.jar
+--add-exports
+java.base/sun.security.action=ALL-UNNAMED
+# for com.ibm.ws.jndi.internal.WASInitialContextFactoryBuilder
+--add-exports
+java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+### Opens
+--add-opens
+java.base/java.util=ALL-UNNAMED
+# needed for EJB Container's ClassDefiner.defineClass
+--add-opens
+java.base/java.lang=ALL-UNNAMED
+--add-opens
+java.base/java.util.concurrent=ALL-UNNAMED
+--add-opens
+java.base/java.io=ALL-UNNAMED
+--add-opens
+java.naming/javax.naming.spi=ALL-UNNAMED
+# for ejbcontainer.ejb2x_fat/S[FL]RemoteTest (yoko setAccessible calls)
+--add-opens
+java.naming/javax.naming=ALL-UNNAMED
+# for ejbcontainer.ejb2x_fat/S[FL]RemoteTest (yoko setAccessible calls)
+--add-opens
+java.rmi/java.rmi=ALL-UNNAMED
+# for ejbcontainer.ejb2x_fat/S[FL]RemoteTest (yoko setAccessible calls)
+--add-opens
+java.sql/java.sql=ALL-UNNAMED
+# for com.ibm.ws.management.j2ee.client_fat_java7:TestMEJBqueryNames/TestMEJBgetAttribute (yoko setAccessible calls)
+--add-opens
+java.management/javax.management=ALL-UNNAMED
+# for com.ibm.ws.transport.iiop_fat:testResolvable/testResolvableThatThrows (yoko setAccessible calls)
+--add-opens
+java.base/java.lang.reflect=ALL-UNNAMED
+# for com.ibm.ws.transport.iiop_fat:testResolvable/testResolvableThatThrows (yoko setAccessible calls)
+--add-opens
+java.desktop/java.awt.image=ALL-UNNAMED
+# for com.ibm.ws.transport.iiop_fat:testResolvable/testResolvableThatThrows (yoko accessible calls)
+--add-opens
+java.base/java.security=ALL-UNNAMED

--- a/official/19.0.0.x/kernel/java12/openj9/Dockerfile
+++ b/official/19.0.0.x/kernel/java12/openj9/Dockerfile
@@ -1,0 +1,86 @@
+FROM adoptopenjdk:12-jre-openj9
+ARG LIBERTY_VERSION=19.0.0.5
+ARG LIBERTY_SHA=ee0fdbc716e9431b73d483555f0e267f007f0286
+ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
+ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
+
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
+
+COPY helpers /opt/ol/helpers
+
+# Install Open Liberty
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip openssl wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
+    && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
+    && sha1sum -c /tmp/wlp.zip.sha1 \
+    && unzip -q /tmp/wlp.zip -d /opt/ol \
+    && rm /tmp/wlp.zip \
+    && rm /tmp/wlp.zip.sha1 \
+    && apt-get remove -y unzip \
+    && apt-get remove -y wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
+    && chown -R 1001:0 /opt/ol/wlp \
+    && chmod -R g+rw /opt/ol/wlp
+
+# Set Path Shortcuts
+ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+    LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ol/wlp/output \
+    WLP_SKIP_MAXPERMSIZE=true
+
+# Configure Open Liberty
+RUN /opt/ol/wlp/bin/server create \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+# Temp workaround so that launcher script doesn't try to open up non-existatnt JDK-only modules
+COPY java9.options /opt/ol/wlp/lib/platform/java/
+
+# Create symlinks && set permissions for non-root user    
+RUN mkdir /logs \
+    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+    && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
+    && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && ln -s /opt/ol/wlp /liberty \
+    && chown -R 1001:0 /opt/ol/wlp/lib/platform/java/java9.options \
+    && chmod -R g+rw /opt/ol/wlp/lib/platform/java/java9.options \
+    && mkdir -p /home/default \
+    && chown -R 1001:0 /home/default \
+    && chmod -R g+rw /home/default \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /opt/ol/wlp/usr \
+    && chmod -R g+rw /opt/ol/wlp/usr \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rw /opt/ol/wlp/output \
+    && chown -R 1001:0 /opt/ol/helpers \
+    && chmod -R g+rw /opt/ol/helpers \
+    && mkdir /etc/wlp \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+
+
+# These settings are needed so that we can run as a different user than 1001 after server warmup
+# TODO: Eventually convert this to OPENJ9_JAVA_OPTIONS once the Liberty server script honors it
+ENV RANDFILE=/tmp/.rnd \
+    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+
+USER 1001
+
+EXPOSE 9080 9443
+
+ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/hazelcast-client.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/hazelcast-client.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+  <network>
+    <redo-operation>true</redo-operation>
+    <discovery-strategies>
+      <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+      </discovery-strategy>
+    </discovery-strategies>
+  </network>
+</hazelcast-client>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/hazelcast-embedded.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/hazelcast-embedded.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+  <network>
+    <join>
+      <multicast enabled="false"/>
+      <tcp-ip enabled="false"/>
+      <discovery-strategies>
+        <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+        </discovery-strategy>
+      </discovery-strategies>
+    </join>
+  </network>
+</hazelcast>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/hazelcast-sessioncache.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/hazelcast-sessioncache.xml
@@ -1,0 +1,11 @@
+<server>
+  <featureManager>
+    <feature>sessionCache-1.0</feature>
+  </featureManager>
+  <httpSessionCache libraryRef="HazelcastLib">
+    <properties hazelcast.config.location="file:${shared.config.dir}/hazelcast/hazelcast.xml"/>
+  </httpSessionCache>
+  <library id="HazelcastLib">
+    <fileset dir="${shared.resource.dir}/hazelcast"/>
+  </library>
+</server>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/http-endpoint.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/http-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="9080" />
+</server>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/http-ssl-endpoint.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/http-ssl-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpsPort="9443" httpPort="9080" />
+</server>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/iiop-endpoint.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/iiop-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <iiopEndpoint id="defaultIiopEndpoint" host="${env.IIOP_ENDPOINT_HOST}" iiopPort="2809" />
+</server>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <iiopEndpoint id="defaultIiopEndpoint" host="${env.IIOP_ENDPOINT_HOST}" iiopPort="2809">
+        <iiopsOptions iiopsPort="9402" sslRef="defaultSSLConfig" />
+    </iiopEndpoint>
+</server>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/jms-endpoint.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/jms-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsPort="7276" />
+</server>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsSSLPort="7286" />
+</server>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/mp-health-check.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/mp-health-check.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>mpHealth-1.0</feature>
+    </featureManager>
+</server>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/mp-monitoring.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/mp-monitoring.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>mpMetrics-1.1</feature>
+        <feature>monitor-1.0</feature>
+    </featureManager>
+    
+    <mpMetrics authentication="false" />
+</server>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>ssl-1.0</feature>
+    </featureManager>
+</server>

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/build/configure.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -Eeox pipefail
+
+##Define variables for XML snippets source and target paths
+WLP_INSTALL_DIR=/opt/ol/wlp
+SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
+SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
+
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+mkdir -p ${SNIPPETS_TARGET}
+
+
+#Check for each Liberty value-add functionality
+
+# MicroProfile Health
+if [ "$MP_HEALTH_CHECK" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
+fi
+
+# MicroProfile Monitoring
+if [ "$MP_MONITORING" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
+fi
+
+# SSL
+if [ "$SSL" == "true" ]; then
+  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
+fi
+
+# HTTP Endpoint
+if [ "$HTTP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
+  fi
+fi
+
+# Hazelcast Session Caching
+if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]
+then
+ cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
+ mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
+ cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
+fi
+
+# IIOP Endpoint
+if [ "$IIOP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
+  fi
+fi
+
+# JMS Endpoint
+if [ "$JMS_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
+  fi
+fi
+# Server start/stop to populate the /output/workarea and make subsequent server starts faster
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.x/kernel/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.x/kernel/java12/openj9/helpers/runtime/docker-server.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+keystorePath="/config/configDropins/defaults/keystore.xml"
+
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
+  then
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export PASSWORD=$(openssl rand -base64 32)
+      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
+
+    # Create the keystore.xml file and place in configDropins
+    mkdir -p $(dirname $keystorePath)
+    echo $XML > $keystorePath
+    fi
+  fi
+fi
+
+# Pass on to the real server run
+exec "$@"

--- a/official/19.0.0.x/kernel/java12/openj9/java9.options
+++ b/official/19.0.0.x/kernel/java12/openj9/java9.options
@@ -1,0 +1,43 @@
+### Exports
+# for JMX VMSupport in LocalConnectorActivator
+--add-exports
+java.base/jdk.internal.vm=ALL-UNNAMED
+# for com.ibm.crypto.ibmkeycert.jar
+--add-exports
+java.base/sun.security.action=ALL-UNNAMED
+# for com.ibm.ws.jndi.internal.WASInitialContextFactoryBuilder
+--add-exports
+java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+### Opens
+--add-opens
+java.base/java.util=ALL-UNNAMED
+# needed for EJB Container's ClassDefiner.defineClass
+--add-opens
+java.base/java.lang=ALL-UNNAMED
+--add-opens
+java.base/java.util.concurrent=ALL-UNNAMED
+--add-opens
+java.base/java.io=ALL-UNNAMED
+--add-opens
+java.naming/javax.naming.spi=ALL-UNNAMED
+# for ejbcontainer.ejb2x_fat/S[FL]RemoteTest (yoko setAccessible calls)
+--add-opens
+java.naming/javax.naming=ALL-UNNAMED
+# for ejbcontainer.ejb2x_fat/S[FL]RemoteTest (yoko setAccessible calls)
+--add-opens
+java.rmi/java.rmi=ALL-UNNAMED
+# for ejbcontainer.ejb2x_fat/S[FL]RemoteTest (yoko setAccessible calls)
+--add-opens
+java.sql/java.sql=ALL-UNNAMED
+# for com.ibm.ws.management.j2ee.client_fat_java7:TestMEJBqueryNames/TestMEJBgetAttribute (yoko setAccessible calls)
+--add-opens
+java.management/javax.management=ALL-UNNAMED
+# for com.ibm.ws.transport.iiop_fat:testResolvable/testResolvableThatThrows (yoko setAccessible calls)
+--add-opens
+java.base/java.lang.reflect=ALL-UNNAMED
+# for com.ibm.ws.transport.iiop_fat:testResolvable/testResolvableThatThrows (yoko setAccessible calls)
+--add-opens
+java.desktop/java.awt.image=ALL-UNNAMED
+# for com.ibm.ws.transport.iiop_fat:testResolvable/testResolvableThatThrows (yoko accessible calls)
+--add-opens
+java.base/java.security=ALL-UNNAMED

--- a/official/19.0.0.x/microProfile2/java12/openj9/Dockerfile
+++ b/official/19.0.0.x/microProfile2/java12/openj9/Dockerfile
@@ -1,0 +1,3 @@
+FROM open-liberty:kernel-java12
+
+RUN cp /opt/ol/wlp/templates/servers/microProfile2/server.xml /config/server.xml

--- a/official/19.0.0.x/springBoot2/java12/openj9/Dockerfile
+++ b/official/19.0.0.x/springBoot2/java12/openj9/Dockerfile
@@ -1,0 +1,3 @@
+FROM open-liberty:kernel-java12
+
+RUN cp /opt/ol/wlp/templates/servers/springBoot2/server.xml /config/server.xml

--- a/official/19.0.0.x/webProfile8/java12/openj9/Dockerfile
+++ b/official/19.0.0.x/webProfile8/java12/openj9/Dockerfile
@@ -1,0 +1,85 @@
+FROM adoptopenjdk:12-jre-openj9
+ARG LIBERTY_VERSION=19.0.0.5
+ARG LIBERTY_SHA=d0b7dfe4f5f2f4c7b6280081c123aab3fc90fdcc
+ARG LIBERTY_BUILD_LABEL=cl190520190522-2227
+ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/$LIBERTY_VERSION/openliberty-webProfile8-$LIBERTY_VERSION.zip
+
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL"
+
+COPY helpers /opt/ol/helpers
+
+# Install Open Liberty
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip openssl wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
+    && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
+    && sha1sum -c /tmp/wlp.zip.sha1 \
+    && unzip -q /tmp/wlp.zip -d /opt/ol \
+    && rm /tmp/wlp.zip \
+    && rm /tmp/wlp.zip.sha1 \
+    && apt-get remove -y unzip \
+    && apt-get remove -y wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
+    && chown -R 1001:0 /opt/ol/wlp \
+    && chmod -R g+rw /opt/ol/wlp
+
+# Set Path Shortcuts
+ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+    LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ol/wlp/output \
+    WLP_SKIP_MAXPERMSIZE=true
+
+# Configure Open Liberty
+RUN /opt/ol/wlp/bin/server create \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+# TODO: Eventually convert this to OPENJ9_JAVA_OPTIONS once the Liberty server script honors it
+ENV RANDFILE=/tmp/.rnd \
+    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+
+# Temp workaround so that launcher script doesn't try to open up non-existatnt JDK-only modules
+COPY java9.options /opt/ol/wlp/lib/platform/java/
+
+# Create symlinks && set permissions for non-root user    
+RUN mkdir /logs \
+    && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && ln -s /opt/ol/wlp /liberty \
+    && chown -R 1001:0 /opt/ol/wlp/lib/platform/java/java9.options \
+    && chmod -R g+rw /opt/ol/wlp/lib/platform/java/java9.options \
+    && mkdir -p /home/default \
+    && chown -R 1001:0 /home/default \
+    && chmod -R g+rw /home/default \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /opt/ol/wlp/usr \
+    && chmod -R g+rw /opt/ol/wlp/usr \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rw /opt/ol/wlp/output \
+    && chown -R 1001:0 /opt/ol/helpers \
+    && chmod -R g+rw /opt/ol/helpers \
+    && mkdir /etc/wlp \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    
+USER 1001
+
+EXPOSE 9080 9443
+
+ENV KEYSTORE_REQUIRED true
+
+ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/hazelcast-client.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/hazelcast-client.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+  <network>
+    <redo-operation>true</redo-operation>
+    <discovery-strategies>
+      <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+      </discovery-strategy>
+    </discovery-strategies>
+  </network>
+</hazelcast-client>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/hazelcast-embedded.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/hazelcast-embedded.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+  <network>
+    <join>
+      <multicast enabled="false"/>
+      <tcp-ip enabled="false"/>
+      <discovery-strategies>
+        <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+        </discovery-strategy>
+      </discovery-strategies>
+    </join>
+  </network>
+</hazelcast>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/hazelcast-sessioncache.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/hazelcast-sessioncache.xml
@@ -1,0 +1,11 @@
+<server>
+  <featureManager>
+    <feature>sessionCache-1.0</feature>
+  </featureManager>
+  <httpSessionCache libraryRef="HazelcastLib">
+    <properties hazelcast.config.location="file:${shared.config.dir}/hazelcast/hazelcast.xml"/>
+  </httpSessionCache>
+  <library id="HazelcastLib">
+    <fileset dir="${shared.resource.dir}/hazelcast"/>
+  </library>
+</server>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/http-endpoint.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/http-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="9080" />
+</server>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/http-ssl-endpoint.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/http-ssl-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpsPort="9443" httpPort="9080" />
+</server>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/iiop-endpoint.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/iiop-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <iiopEndpoint id="defaultIiopEndpoint" host="${env.IIOP_ENDPOINT_HOST}" iiopPort="2809" />
+</server>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <iiopEndpoint id="defaultIiopEndpoint" host="${env.IIOP_ENDPOINT_HOST}" iiopPort="2809">
+        <iiopsOptions iiopsPort="9402" sslRef="defaultSSLConfig" />
+    </iiopEndpoint>
+</server>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/jms-endpoint.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/jms-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsPort="7276" />
+</server>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsSSLPort="7286" />
+</server>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/mp-health-check.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/mp-health-check.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>mpHealth-1.0</feature>
+    </featureManager>
+</server>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/mp-monitoring.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/mp-monitoring.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>mpMetrics-1.1</feature>
+        <feature>monitor-1.0</feature>
+    </featureManager>
+    
+    <mpMetrics authentication="false" />
+</server>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>ssl-1.0</feature>
+    </featureManager>
+</server>

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/build/configure.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -Eeox pipefail
+
+##Define variables for XML snippets source and target paths
+WLP_INSTALL_DIR=/opt/ol/wlp
+SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
+SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
+
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+mkdir -p ${SNIPPETS_TARGET}
+
+
+#Check for each Liberty value-add functionality
+
+# MicroProfile Health
+if [ "$MP_HEALTH_CHECK" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
+fi
+
+# MicroProfile Monitoring
+if [ "$MP_MONITORING" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
+fi
+
+# SSL
+if [ "$SSL" == "true" ]; then
+  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
+fi
+
+# HTTP Endpoint
+if [ "$HTTP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
+  fi
+fi
+
+# Hazelcast Session Caching
+if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]
+then
+ cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
+ mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
+ cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
+fi
+
+# IIOP Endpoint
+if [ "$IIOP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
+  fi
+fi
+
+# JMS Endpoint
+if [ "$JMS_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
+  fi
+fi
+# Server start/stop to populate the /output/workarea and make subsequent server starts faster
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.x/webProfile8/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.x/webProfile8/java12/openj9/helpers/runtime/docker-server.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+keystorePath="/config/configDropins/defaults/keystore.xml"
+
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
+  then
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export PASSWORD=$(openssl rand -base64 32)
+      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
+
+    # Create the keystore.xml file and place in configDropins
+    mkdir -p $(dirname $keystorePath)
+    echo $XML > $keystorePath
+    fi
+  fi
+fi
+
+# Pass on to the real server run
+exec "$@"

--- a/official/19.0.0.x/webProfile8/java12/openj9/java9.options
+++ b/official/19.0.0.x/webProfile8/java12/openj9/java9.options
@@ -1,0 +1,43 @@
+### Exports
+# for JMX VMSupport in LocalConnectorActivator
+--add-exports
+java.base/jdk.internal.vm=ALL-UNNAMED
+# for com.ibm.crypto.ibmkeycert.jar
+--add-exports
+java.base/sun.security.action=ALL-UNNAMED
+# for com.ibm.ws.jndi.internal.WASInitialContextFactoryBuilder
+--add-exports
+java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+### Opens
+--add-opens
+java.base/java.util=ALL-UNNAMED
+# needed for EJB Container's ClassDefiner.defineClass
+--add-opens
+java.base/java.lang=ALL-UNNAMED
+--add-opens
+java.base/java.util.concurrent=ALL-UNNAMED
+--add-opens
+java.base/java.io=ALL-UNNAMED
+--add-opens
+java.naming/javax.naming.spi=ALL-UNNAMED
+# for ejbcontainer.ejb2x_fat/S[FL]RemoteTest (yoko setAccessible calls)
+--add-opens
+java.naming/javax.naming=ALL-UNNAMED
+# for ejbcontainer.ejb2x_fat/S[FL]RemoteTest (yoko setAccessible calls)
+--add-opens
+java.rmi/java.rmi=ALL-UNNAMED
+# for ejbcontainer.ejb2x_fat/S[FL]RemoteTest (yoko setAccessible calls)
+--add-opens
+java.sql/java.sql=ALL-UNNAMED
+# for com.ibm.ws.management.j2ee.client_fat_java7:TestMEJBqueryNames/TestMEJBgetAttribute (yoko setAccessible calls)
+--add-opens
+java.management/javax.management=ALL-UNNAMED
+# for com.ibm.ws.transport.iiop_fat:testResolvable/testResolvableThatThrows (yoko setAccessible calls)
+--add-opens
+java.base/java.lang.reflect=ALL-UNNAMED
+# for com.ibm.ws.transport.iiop_fat:testResolvable/testResolvableThatThrows (yoko setAccessible calls)
+--add-opens
+java.desktop/java.awt.image=ALL-UNNAMED
+# for com.ibm.ws.transport.iiop_fat:testResolvable/testResolvableThatThrows (yoko accessible calls)
+--add-opens
+java.base/java.security=ALL-UNNAMED


### PR DESCRIPTION
fixes #openliberty/ci.docker#84 

Since Java 12 is not a LTS only the latest profiles have been updated.
No configuration has been touched though. This PR only updates the FROM-clause to a adopt-jre-12