### PR TITLE
Added keystore XML element

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This section describes the optional enterprise functionality that can be enabled
 * `KEYSTORE_REQUIRED`
   *  Description: Enables keystore element, which holds the key that is required to make an SSL connection.
   *  XML Snippet Location: [keystore.xml](/common/helpers/build/configuration_snippets/keystore.xml)
-  *  Note: Keystore PASSWORD and security certificate will be generated if users do not provide their own.
+  *  Note: Keystore password and security certificate will be generated if users do not provide their own.
 
 
 ### Session Caching

--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ This section describes the optional enterprise functionality that can be enabled
 * `KEYSTORE_REQUIRED`
   *  Description: Enables keystore element, which holds the key that is required to make an SSL connection.
   *  XML Snippet Location: [keystore.xml](/common/helpers/build/configuration_snippets/keystore.xml)
-  *  Note: Keystore password and security certificate will be generated if users do not provide their own.
-
+  *  Note: Keystore password and security certificate will be generated if users do not provide their own. The user provided keystore.xml (with defined password) and certificate can be applied using the following commands inside of their Dockerfile:
+     ```dockerfile
+     COPY --chown=1001:0 keystore.xml /config/configDropins/overrides
+     COPY --chown=1001:0 <certificate> /output/resources/security/
+     ```
 
 ### Session Caching
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ This section describes the optional enterprise functionality that can be enabled
 * `OIDC_CONFIG`
   *  Decription: Enable OpenIdConnect Client configuration to be read from environment variables.  
   *  XML Snippet Location: [oidc-config.xml](/common/helpers/build/configuration_snippets/oidc-config.xml)
-  *  Note: The following variables will be read:  OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL.  
+  *  Note: The following variables will be read:  OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL.
+* `KEYSTORE_REQUIRED`
+  *  Description: Enables keystore element, which holds the key that is required to make an SSL connection.
+  *  XML Snippet Location: [keystore.xml](/common/helpers/build/configuration_snippets/keystore.xml)
+  *  Note: Keystore PASSWORD and security certificate will be generated if users do not provide their own.
 
 
 ### Session Caching

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This section describes the optional enterprise functionality that can be enabled
 * `KEYSTORE_REQUIRED`
   *  Description: Enables keystore element, which holds the key that is required to make an SSL connection.
   *  XML Snippet Location: [keystore.xml](/common/helpers/build/configuration_snippets/keystore.xml)
-  *  Note: Keystore password and security certificate will be generated if users do not provide their own. The user provided keystore.xml (with defined password) and certificate can be applied using the following commands inside of their Dockerfile:
+  *  Note: Keystore password and security certificate will be generated if you do not provide your own. You can provide keystore.xml (with defined password) and certificate using the following instructions inside your Dockerfile:
      ```dockerfile
      COPY --chown=1001:0 keystore.xml /config/configDropins/overrides
      COPY --chown=1001:0 <certificate> /output/resources/security/

--- a/common/configure_ibmsfj.sh
+++ b/common/configure_ibmsfj.sh
@@ -71,8 +71,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/common/configure_ibmsfj.sh
+++ b/common/configure_ibmsfj.sh
@@ -62,3 +62,17 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi

--- a/common/helpers/build/configuration_snippets/keystore.xml
+++ b/common/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/common/helpers/build/configure.sh
+++ b/common/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/common/helpers/build/configure.sh
+++ b/common/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/common/helpers/build/configure.sh
+++ b/common/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/common/helpers/runtime/docker-server.sh
+++ b/common/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/common/helpers/runtime/docker-server.sh
+++ b/common/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/common/helpers/runtime/docker-server.sh
+++ b/common/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/community/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/community/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/community/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/community/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/community/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/community/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/community/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/community/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/community/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/community/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/community/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/community/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/community/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/javaee8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/18.0.0.4/javaee8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/18.0.0.4/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/18.0.0.4/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/18.0.0.4/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/javaee8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/18.0.0.4/javaee8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/18.0.0.4/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/official/18.0.0.4/javaee8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/official/18.0.0.4/javaee8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/official/18.0.0.4/javaee8/java8/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/18.0.0.4/javaee8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/javaee8/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/18.0.0.4/javaee8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/javaee8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/javaee8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/javaee8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/kernel/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/18.0.0.4/kernel/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/18.0.0.4/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/18.0.0.4/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/18.0.0.4/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/18.0.0.4/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/18.0.0.4/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/18.0.0.4/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/18.0.0.4/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/18.0.0.4/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/18.0.0.4/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/18.0.0.4/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/18.0.0.4/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/18.0.0.4/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/18.0.0.4/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/kernel/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/18.0.0.4/kernel/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/18.0.0.4/kernel/java8/openj9/helpers/build/configure.sh
+++ b/official/18.0.0.4/kernel/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/kernel/java8/openj9/helpers/build/configure.sh
+++ b/official/18.0.0.4/kernel/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/kernel/java8/openj9/helpers/build/configure.sh
+++ b/official/18.0.0.4/kernel/java8/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/18.0.0.4/kernel/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/kernel/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/18.0.0.4/kernel/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/kernel/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/kernel/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/kernel/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/webProfile8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/18.0.0.4/webProfile8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/18.0.0.4/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/official/18.0.0.4/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/official/18.0.0.4/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/18.0.0.4/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/official/18.0.0.4/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/18.0.0.4/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/18.0.0.4/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/18.0.0.4/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/18.0.0.4/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/javaee8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/19.0.0.3/javaee8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/19.0.0.3/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.3/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/19.0.0.3/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/javaee8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/19.0.0.3/javaee8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/19.0.0.3/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.3/javaee8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.3/javaee8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.3/javaee8/java8/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.3/javaee8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/javaee8/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/19.0.0.3/javaee8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/javaee8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/javaee8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/javaee8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/kernel/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/19.0.0.3/kernel/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/19.0.0.3/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/19.0.0.3/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/19.0.0.3/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/19.0.0.3/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.3/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/19.0.0.3/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/19.0.0.3/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/19.0.0.3/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/19.0.0.3/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/19.0.0.3/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/19.0.0.3/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.3/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/19.0.0.3/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/kernel/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/19.0.0.3/kernel/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/19.0.0.3/kernel/java8/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.3/kernel/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/kernel/java8/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.3/kernel/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/kernel/java8/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.3/kernel/java8/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.3/kernel/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/kernel/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/19.0.0.3/kernel/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/kernel/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/kernel/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/kernel/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/webProfile8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/19.0.0.3/webProfile8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/19.0.0.3/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.3/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.3/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/19.0.0.3/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/official/19.0.0.3/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/19.0.0.3/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/19.0.0.3/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/19.0.0.3/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/19.0.0.3/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/javaee8/java11/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/javaee8/java11/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/javaee8/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java11/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/javaee8/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java11/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/javaee8/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java11/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/javaee8/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java11/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/javaee8/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java11/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/javaee8/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java11/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/javaee8/java12/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/javaee8/java12/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/javaee8/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java12/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/javaee8/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java12/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/javaee8/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java12/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/javaee8/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java12/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/javaee8/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java12/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/javaee8/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java12/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/javaee8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/javaee8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/javaee8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/javaee8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/javaee8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/javaee8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/javaee8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/kernel/java11/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/kernel/java11/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/kernel/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java11/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/kernel/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java11/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/kernel/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java11/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/kernel/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java11/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/kernel/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java11/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/kernel/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java11/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/kernel/java12/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/kernel/java12/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/kernel/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java12/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/kernel/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java12/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/kernel/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java12/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/kernel/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java12/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/kernel/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java12/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/kernel/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java12/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/kernel/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/kernel/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/kernel/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/kernel/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/kernel/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/kernel/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/kernel/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/kernel/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/kernel/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/kernel/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/webProfile8/java11/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/webProfile8/java11/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/webProfile8/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java11/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/webProfile8/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java11/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/webProfile8/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java11/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/webProfile8/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java11/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/webProfile8/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java11/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/webProfile8/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java11/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/webProfile8/java12/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/webProfile8/java12/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/webProfile8/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java12/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/webProfile8/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java12/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/webProfile8/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java12/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/webProfile8/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java12/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/webProfile8/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java12/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/webProfile8/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java12/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/webProfile8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/webProfile8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/webProfile8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -70,8 +70,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
 fi

--- a/official/latest/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -62,5 +62,19 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$KEYSTORE_REQUIRED" = "true" ]
+then
+  # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,22 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
 
 if [ "$KEYSTORE_REQUIRED" = "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
+    # Check if the password is set already
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export NEWPASSWORD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$NEWPASSWORD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
+      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi

--- a/official/latest/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
@@ -15,8 +15,8 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32 | tr -d "/")
-      sed -i.bak "s/REPLACE/$KEYSTOREPWD/g" $SNIPPETS_SOURCE/keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
       cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi


### PR DESCRIPTION
Added the `keystore.xml` file into the `configuration_snippets` folder so that it holds the password for keystore XML element. Changed the scripts in build time `configure.sh`, the runtime script, `docker-server.sh`, to generate a password if the password is not set.

With this change, users can either use their own `keystore.xml` and security certificate or let our script generate those for them by enabling `KEYSTORE_REQUIRED` in their Dockerfile

The changes were tested and proven to be working in the following cases:
- Simple `docker build` and `docker run` with and without `RUN configure.sh` inside of the Dockerfile. The password and certificate were generated in the process.
- User provide their own certificate and password, with and without `RUN configure.sh` inside of their Dockerfile.