### PR TITLE
Added keystore XML element

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ This section describes the optional enterprise functionality that can be enabled
   *  Decription: Monitor the server runtime environment and application metrics by using Liberty features `mpMetrics-1.1` (implements [Microprofile Metrics](https://microprofile.io/project/eclipse/microprofile-metrics)) and `monitor-1.0`.
   *  XML Snippet Location: [mp-monitoring.xml](/common/helpers/build/configuration_snippets/mp-monitoring.xml)
   *  Note: With this option, `/metrics` endpoint is configured without authentication to support the environments that do not yet support scraping secured endpoints.
-* `SSL` 
-  *  Decription: Enable SSL in Liberty by adding the `ssl-1.0` feature.
-  *  XML Snippet Location:  [ssl.xml](/common/helpers/build/configuration_snippets/ssl.xml).
+* `TLS` or `SSL` (SSL is being deprecated)
+  *  Decription: Enable Transport Security in Liberty by adding the `transportSecurity-1.0` feature (includes support for SSL).
+  *  XML Snippet Location:  [keystore.xml](ga/latest/kernel/helpers/build/configuration_snippets/keystore.xml).
 * `IIOP_ENDPOINT`
   *  Decription: Add configuration properties for an IIOP endpoint.
   *  XML Snippet Location: [iiop-ssl-endpoint.xml](/common/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml) when SSL is enabled. Otherwise, [iiop-endpoint.xml](/common/helpers/build/configuration_snippets/iiop-endpoint.xml).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This section describes the optional enterprise functionality that can be enabled
   *  Note: With this option, `/metrics` endpoint is configured without authentication to support the environments that do not yet support scraping secured endpoints.
 * `TLS` or `SSL` (SSL is being deprecated)
   *  Decription: Enable Transport Security in Liberty by adding the `transportSecurity-1.0` feature (includes support for SSL).
-  *  XML Snippet Location:  [keystore.xml](ga/latest/kernel/helpers/build/configuration_snippets/keystore.xml).
+  *  XML Snippet Location:  [keystore.xml](/common/helpers/build/configuration_snippets/keystore.xml).
 * `IIOP_ENDPOINT`
   *  Decription: Add configuration properties for an IIOP endpoint.
   *  XML Snippet Location: [iiop-ssl-endpoint.xml](/common/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml) when SSL is enabled. Otherwise, [iiop-endpoint.xml](/common/helpers/build/configuration_snippets/iiop-endpoint.xml).

--- a/common/README.md
+++ b/common/README.md
@@ -169,11 +169,11 @@ The `springBoot` images introduce capabilities specific to the support of Spring
 
 When an `open-liberty` image starts, it can generate a Liberty server XML snippet in `/config/configDropins/defaults/keystore.xml` that specifies a `keyStore` stanza with a generated password. This causes Open Liberty to generate a default keystore and truststore with a self-signed certificate when it starts. This can request this by setting:
 
-```console
+```dockerfile
 ARG TLS=TRUE
 ```
 or
-```console
+```dockerfile
 ARG SSL=TRUE
 ```
 

--- a/common/README.md
+++ b/common/README.md
@@ -167,17 +167,17 @@ The `springBoot` images introduce capabilities specific to the support of Spring
 
 # Providing your own keystore/truststore
 
-When an `open-liberty` image starts, it can generate a Liberty server XML snippet in `/config/configDropins/defaults/keystore.xml` that specifies a `keyStore` stanza with a generated password. This causes Open Liberty to generate a default keystore and truststore with a self-signed certificate when it starts. The `javaee8` and `javaee7` images do this automatically, but other images can request this by setting:
+When an `open-liberty` image starts, it can generate a Liberty server XML snippet in `/config/configDropins/defaults/keystore.xml` that specifies a `keyStore` stanza with a generated password. This causes Open Liberty to generate a default keystore and truststore with a self-signed certificate when it starts. This can request this by setting:
 
 ```console
-ENV KEYSTORE_REQUIRED "true"
+ARG TLS=TRUE
 ```
-
-When providing your own keystore/truststore, this default behavior can be disabled by adding:
-
+or
 ```console
-ENV KEYSTORE_REQUIRED "false"
+ARG SSL=TRUE
 ```
+
+When providing your own keystore/truststore, you don't need to write anything because TLS/SSL is disabled by default.
 
 It is good practice to place the keystore customization in `/config/configDropins/defaults/keystore.xml` even when not generated since this makes it easier to find and makes moving to the websphere-liberty docker image simpler.
 

--- a/common/configure_ibmsfj.sh
+++ b/common/configure_ibmsfj.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,9 +51,23 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
+fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
 fi

--- a/common/helpers/build/configuration_snippets/keystore.xml
+++ b/common/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/common/helpers/build/configuration_snippets/ssl.xml
+++ b/common/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/common/helpers/build/configure.sh
+++ b/common/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/common/helpers/runtime/docker-server.sh
+++ b/common/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/community/latest/javaee7/java8/ibmsfj/Dockerfile.ubi-min
+++ b/community/latest/javaee7/java8/ibmsfj/Dockerfile.ubi-min
@@ -1,4 +1,3 @@
 FROM open-liberty:kernel-ubi-min
-ENV KEYSTORE_REQUIRED "true"
 
 RUN cp /opt/ol/wlp/templates/servers/javaee7/server.xml /config/server.xml

--- a/community/latest/javaee8/java8/ibmsfj/Dockerfile.ubi-min
+++ b/community/latest/javaee8/java8/ibmsfj/Dockerfile.ubi-min
@@ -75,7 +75,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/community/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/community/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/community/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/community/latest/kernel/java8/ibmsfj/Dockerfile.ubi-min
+++ b/community/latest/kernel/java8/ibmsfj/Dockerfile.ubi-min
@@ -78,7 +78,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/community/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/community/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/community/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
+++ b/community/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/community/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/community/latest/webProfile8/java8/ibmsfj/Dockerfile.ubi-min
+++ b/community/latest/webProfile8/java8/ibmsfj/Dockerfile.ubi-min
@@ -75,7 +75,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/community/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/javaee7/java11/openj9/Dockerfile
+++ b/official/latest/javaee7/java11/openj9/Dockerfile
@@ -1,4 +1,3 @@
 FROM open-liberty:kernel-java11
-ENV KEYSTORE_REQUIRED "true"
 
 RUN cp /opt/ol/wlp/templates/servers/javaee7/server.xml /config/server.xml

--- a/official/latest/javaee7/java8/ibmjava/Dockerfile
+++ b/official/latest/javaee7/java8/ibmjava/Dockerfile
@@ -1,4 +1,3 @@
 FROM open-liberty:kernel-java8-ibm
-ENV KEYSTORE_REQUIRED "true"
 
 RUN cp /opt/ol/wlp/templates/servers/javaee7/server.xml /config/server.xml

--- a/official/latest/javaee7/java8/ibmsfj/Dockerfile
+++ b/official/latest/javaee7/java8/ibmsfj/Dockerfile
@@ -1,4 +1,3 @@
 FROM open-liberty:kernel-java8-ibmsfj
-ENV KEYSTORE_REQUIRED "true"
 
 RUN cp /opt/ol/wlp/templates/servers/javaee7/server.xml /config/server.xml

--- a/official/latest/javaee7/java8/openj9/Dockerfile
+++ b/official/latest/javaee7/java8/openj9/Dockerfile
@@ -1,4 +1,3 @@
 FROM open-liberty:kernel-java8-openj9
-ENV KEYSTORE_REQUIRED "true"
 
 RUN cp /opt/ol/wlp/templates/servers/javaee7/server.xml /config/server.xml

--- a/official/latest/javaee8/java11/openj9/Dockerfile
+++ b/official/latest/javaee8/java11/openj9/Dockerfile
@@ -79,7 +79,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/javaee8/java11/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/javaee8/java11/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/javaee8/java11/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/javaee8/java11/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/javaee8/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java11/openj9/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/javaee8/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java11/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/javaee8/java12/openj9/Dockerfile
+++ b/official/latest/javaee8/java12/openj9/Dockerfile
@@ -79,7 +79,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/javaee8/java12/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/javaee8/java12/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/javaee8/java12/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/javaee8/java12/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/javaee8/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java12/openj9/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/javaee8/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java12/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/javaee8/java8/ibmjava/Dockerfile
+++ b/official/latest/javaee8/java8/ibmjava/Dockerfile
@@ -72,7 +72,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/javaee8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/javaee8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/javaee8/java8/ibmjava/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/javaee8/java8/ibmjava/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/javaee8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/ibmjava/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/javaee8/java8/ibmsfj/Dockerfile
+++ b/official/latest/javaee8/java8/ibmsfj/Dockerfile
@@ -67,7 +67,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/javaee8/java8/openj9/Dockerfile
+++ b/official/latest/javaee8/java8/openj9/Dockerfile
@@ -71,7 +71,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/javaee8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/javaee8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/javaee8/java8/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/javaee8/java8/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/javaee8/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/javaee8/java8/openj9/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/javaee8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/javaee8/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/kernel/java11/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/kernel/java11/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/kernel/java11/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/kernel/java11/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/kernel/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java11/openj9/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/kernel/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java11/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/kernel/java12/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/kernel/java12/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/kernel/java12/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/kernel/java12/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/kernel/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java12/openj9/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/kernel/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java12/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/kernel/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/kernel/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/kernel/java8/ibmjava/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/kernel/java8/ibmjava/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/kernel/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/ibmjava/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/kernel/java8/ibmsfj/Dockerfile
+++ b/official/latest/kernel/java8/ibmsfj/Dockerfile
@@ -70,7 +70,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/kernel/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/ibmsfj/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/kernel/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/kernel/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/kernel/java8/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/kernel/java8/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/kernel/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/kernel/java8/openj9/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/kernel/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/kernel/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/webProfile7/java8/openj9/Dockerfile
+++ b/official/latest/webProfile7/java8/openj9/Dockerfile
@@ -1,4 +1,3 @@
 FROM open-liberty:kernel-java8-openj9
-ENV KEYSTORE_REQUIRED "true"
 
 RUN cp /opt/ol/wlp/templates/servers/webProfile7/server.xml /config/server.xml

--- a/official/latest/webProfile8/java11/openj9/Dockerfile
+++ b/official/latest/webProfile8/java11/openj9/Dockerfile
@@ -79,7 +79,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/webProfile8/java11/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/webProfile8/java11/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/webProfile8/java11/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/webProfile8/java11/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/webProfile8/java11/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java11/openj9/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/webProfile8/java11/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java11/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/webProfile8/java12/openj9/Dockerfile
+++ b/official/latest/webProfile8/java12/openj9/Dockerfile
@@ -79,7 +79,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/webProfile8/java12/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/webProfile8/java12/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/webProfile8/java12/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/webProfile8/java12/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/webProfile8/java12/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java12/openj9/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/webProfile8/java12/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java12/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/webProfile8/java8/ibmjava/Dockerfile
+++ b/official/latest/webProfile8/java8/ibmjava/Dockerfile
@@ -71,7 +71,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/webProfile8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/webProfile8/java8/ibmjava/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/webProfile8/java8/ibmjava/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/webProfile8/java8/ibmsfj/Dockerfile
+++ b/official/latest/webProfile8/java8/ibmsfj/Dockerfile
@@ -67,7 +67,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/ibmsfj/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi

--- a/official/latest/webProfile8/java8/openj9/Dockerfile
+++ b/official/latest/webProfile8/java8/openj9/Dockerfile
@@ -72,7 +72,5 @@ USER 1001
 
 EXPOSE 9080 9443
 
-ENV KEYSTORE_REQUIRED true
-
 ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/official/latest/webProfile8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/official/latest/webProfile8/java8/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,6 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/official/latest/webProfile8/java8/openj9/helpers/build/configuration_snippets/ssl.xml
+++ b/official/latest/webProfile8/java8/openj9/helpers/build/configuration_snippets/ssl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>ssl-1.0</feature>
-    </featureManager>
-</server>

--- a/official/latest/webProfile8/java8/openj9/helpers/build/configure.sh
+++ b/official/latest/webProfile8/java8/openj9/helpers/build/configure.sh
@@ -23,14 +23,9 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -47,7 +42,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -56,11 +51,26 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
   fi
 fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+    # Check if the password is set already
+    if [ ! -e $keystorePath ]
+    then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    fi
+fi
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/official/latest/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
+++ b/official/latest/webProfile8/java8/openj9/helpers/runtime/docker-server.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-keystorePath="/config/configDropins/defaults/keystore.xml"
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
 
-if [ "$KEYSTORE_REQUIRED" = "true" ]
+keystorePath="$SNIPPETS_TARGET/keystore.xml"
+
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
   if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
   then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export PASSWORD=$(openssl rand -base64 32)
-      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
-
-    # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
-    echo $XML > $keystorePath
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
     fi
   fi
 fi


### PR DESCRIPTION
Added the `keystore.xml` file into the `configuration_snippets` folder so that it holds the password for keystore XML element. Changed the scripts in build time `configure.sh`, the runtime script, `docker-server.sh`, to generate a password if the password is not set.

With this change, users can either use their own `keystore.xml` and security certificate or let our script generate those for them by enabling `KEYSTORE_REQUIRED` in their Dockerfile

The changes were tested and proven to be working in the following cases:
- Simple `docker build` and `docker run` with and without `RUN configure.sh` inside of the Dockerfile. The password and certificate were generated in the process.
- User provide their own certificate and password, with and without `RUN configure.sh` inside of their Dockerfile.