### PR TITLE
Pre-populate multi-layer class cache in images

### DIFF
--- a/build/test-pet-clinic/Dockerfile
+++ b/build/test-pet-clinic/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=openliberty/open-liberty:kernel-ubi
+ARG IMAGE=openliberty/open-liberty:kernel-java8-openj9-ubi
 FROM ${IMAGE} as staging
 
 COPY --chown=1001:0 spring-petclinic-2.1.0.BUILD-SNAPSHOT.jar /staging/myFatApp.jar
@@ -12,3 +12,5 @@ FROM ${IMAGE}
 COPY --chown=1001:0 server.xml /config/server.xml
 COPY --from=staging /staging/lib.index.cache /lib.index.cache
 COPY --from=staging /staging/myThinApp.jar /config/dropins/spring/myThinApp.jar
+
+RUN configure.sh

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -70,16 +70,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
-# 1) Make sure the following Java commands don't disturb our class cache until we're ready to populate it
-# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
-# 2) Explicity create a class cache layer for this image layer here rather than allowing
-# `server start` to do it, which will lead to problems because multiple JVMs will be started.
-# 3) Populate the newly created class cache layer.
-RUN unset IBM_JAVA_OPTIONS \
-    && java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx4m -version \
-    && export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/" \
-    && server start \
-    && server stop \
+# Create a new SCC layer, args are layer size and number of iterations to run to populate it
+RUN populate_scc.sh 4m 3 \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -70,6 +70,19 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
+# 1) Make sure the following Java commands don't disturb our class cache until we're ready to populate it
+# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
+# 2) Explicity create a class cache layer for this image layer here rather than allowing
+# `server start` to do it, which will lead to problems because multiple JVMs will be started.
+# 3) Populate the newly created class cache layer.
+RUN unset IBM_JAVA_OPTIONS \
+    && java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx4m -version \
+    && export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/" \
+    && server start \
+    && server stop \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk13
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk13
@@ -70,16 +70,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
-# 1) Make sure the following Java commands don't disturb our class cache until we're ready to populate it
-# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
-# 2) Explicity create a class cache layer for this image layer here rather than allowing
-# `server start` to do it, which will lead to problems because multiple JVMs will be started.
-# 3) Populate the newly created class cache layer.
-RUN unset IBM_JAVA_OPTIONS \
-    && java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx4m -version \
-    && export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/" \
-    && server start \
-    && server stop \
+# Create a new SCC layer, args are layer size and number of iterations to run to populate it
+RUN populate_scc.sh 4m 3 \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk13
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk13
@@ -70,6 +70,19 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
+# 1) Make sure the following Java commands don't disturb our class cache until we're ready to populate it
+# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
+# 2) Explicity create a class cache layer for this image layer here rather than allowing
+# `server start` to do it, which will lead to problems because multiple JVMs will be started.
+# 3) Populate the newly created class cache layer.
+RUN unset IBM_JAVA_OPTIONS \
+    && java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx4m -version \
+    && export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/" \
+    && server start \
+    && server stop \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -70,16 +70,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
-# 1) Make sure the following Java commands don't disturb our class cache until we're ready to populate it
-# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
-# 2) Explicity create a class cache layer for this image layer here rather than allowing
-# `server start` to do it, which will lead to problems because multiple JVMs will be started.
-# 3) Populate the newly created class cache layer.
-RUN unset IBM_JAVA_OPTIONS \
-    && java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx4m -version \
-    && export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/" \
-    && server start \
-    && server stop \
+# Create a new SCC layer, args are layer size and number of iterations to run to populate it
+RUN populate_scc.sh 4m 3 \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -70,6 +70,19 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
+# 1) Make sure the following Java commands don't disturb our class cache until we're ready to populate it
+# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
+# 2) Explicity create a class cache layer for this image layer here rather than allowing
+# `server start` to do it, which will lead to problems because multiple JVMs will be started.
+# 3) Populate the newly created class cache layer.
+RUN unset IBM_JAVA_OPTIONS \
+    && java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx4m -version \
+    && export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/" \
+    && server start \
+    && server stop \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -41,7 +41,7 @@ RUN /opt/ol/wlp/bin/server create \
     && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
 
 
-# Create symlinks && set permissions for non-root user    
+# Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
@@ -66,6 +66,19 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
+# 1) Make sure the following Java commands don't disturb our class cache until we're ready to populate it
+# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
+# 2) Explicity create a class cache layer for this image layer here rather than allowing
+# `server start` to do it, which will lead to problems because multiple JVMs will be started.
+# 3) Populate the newly created class cache layer.
+RUN unset IBM_JAVA_OPTIONS \
+    && java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx4m -version \
+    && export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/" \
+    && server start \
+    && server stop \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -66,16 +66,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
-# 1) Make sure the following Java commands don't disturb our class cache until we're ready to populate it
-# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
-# 2) Explicity create a class cache layer for this image layer here rather than allowing
-# `server start` to do it, which will lead to problems because multiple JVMs will be started.
-# 3) Populate the newly created class cache layer.
-RUN unset IBM_JAVA_OPTIONS \
-    && java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx4m -version \
-    && export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/" \
-    && server start \
-    && server stop \
+# Create a new SCC layer, args are layer size and number of iterations to run to populate it
+RUN populate_scc.sh 4m 3 \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/helpers/build/configure.sh
+++ b/releases/latest/kernel/helpers/build/configure.sh
@@ -77,16 +77,5 @@ then
   fi
 fi
 
-# Make sure the following Java commands don't disturb our class cache until we're ready to populate it
-# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
-unset IBM_JAVA_OPTIONS
-
-# Explicity create a class cache layer for this image layer here rather than allowing
-# `server start` to do it, which will lead to problems because multiple JVMs will be started.
-java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx8m -version
-
-# Populate the newly created class cache layer.
-export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
-
-# Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+# Create a new SCC layer, args are layer size and number of iterations to run to populate it
+populate_scc.sh 8m 3

--- a/releases/latest/kernel/helpers/build/configure.sh
+++ b/releases/latest/kernel/helpers/build/configure.sh
@@ -77,5 +77,16 @@ then
   fi
 fi
 
+# Make sure the following Java commands don't disturb our class cache until we're ready to populate it
+# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
+unset IBM_JAVA_OPTIONS
+
+# Explicity create a class cache layer for this image layer here rather than allowing
+# `server start` to do it, which will lead to problems because multiple JVMs will be started.
+java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx8m -version
+
+# Populate the newly created class cache layer.
+export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
 /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/releases/latest/kernel/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel/helpers/build/populate_scc.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -Eeox pipefail
+
+SCC_SIZE="$1" # Size of the SCC layer
+ITERATIONS="$2" # Number of iterations to run to populate it
+
+# Make sure the following Java commands don't disturb our class cache until we're ready to populate it
+# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
+unset IBM_JAVA_OPTIONS
+
+# Explicity create a class cache layer for this image layer here rather than allowing
+# `server start` to do it, which will lead to problems because multiple JVMs will be started.
+java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
+
+# Populate the newly created class cache layer.
+export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+
+# Server start/stop to populate the /output/workarea and make subsequent server starts faster
+for ((i=0; i<$ITERATIONS; i++))
+do
+  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+done
+
+rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*


### PR DESCRIPTION
This patch demonstrates how to use OpenJ9's [multi-layer class cache](https://blog.openj9.org/2019/11/05/the-multi-layer-shared-class-cache-for-docker/) by creating and pre-populating a new class cache layer in the kernel image and images that call `configure.sh`.

Notes:

- Each class cache layer is explicitly sized. I used 8 MiB for starters, which is filled to 100% in my tests, but the number is otherwise arbitrary.
- I've applied the changes to a minimal set of images for starters to make it easier to review and discuss, but the changes are applicable to various other Dockerfiles in the source tree.
- The `adoptopenjdk:8-jre-openj9` images on Dockerhub are not yet up to date, I used `adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u-nightly` to test.