### PR TITLE
Add community images based on Java 13 (OpenJ9)

### DIFF
--- a/community/latest/full/java13/openj9/Dockerfile.ubi
+++ b/community/latest/full/java13/openj9/Dockerfile.ubi
@@ -1,0 +1,3 @@
+FROM openliberty/open-liberty:kernel-java13-openj9-ubi
+
+RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml

--- a/community/latest/kernel/java13/openj9/Dockerfile.ubi
+++ b/community/latest/kernel/java13/openj9/Dockerfile.ubi
@@ -1,0 +1,82 @@
+FROM adoptopenjdk/openjdk13-openj9:ubi-minimal-jre
+ARG LIBERTY_VERSION=19.0.0.11
+ARG LIBERTY_SHA=08408df2ef3bb4259a9c7bedad93cd408d21eb0e
+ARG LIBERTY_BUILD_LABEL=cl191120191031-0300
+ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
+
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.version="$LIBERTY_VERSION" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL" \
+      vendor="Open Liberty" \
+      name="Open Liberty" \
+      version="$LIBERTY_VERSION" \
+      summary="Image for Open Liberty with IBM's SFJ and UBI minimal" \
+      description="This image contains the Open Liberty runtime with IBM's SFJ and Red Hat UBI minimal as the base OS.  For more information on this image please see https://github.com/OpenLiberty/ci.docker#building-an-application-image"
+
+COPY helpers /opt/ol/helpers
+COPY licenses /licenses
+
+# Install Open Liberty
+RUN microdnf -y install shadow-utils wget unzip \
+    && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
+    && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
+    && sha1sum -c /tmp/wlp.zip.sha1 \
+    && unzip -q /tmp/wlp.zip -d /opt/ol \
+    && rm /tmp/wlp.zip \
+    && rm /tmp/wlp.zip.sha1 \
+    && adduser -u 1001 -r -g root -s /usr/sbin/nologin default \
+    && microdnf -y remove shadow-utils wget unzip \
+    && microdnf clean all \
+    && chown -R 1001:0 /opt/ol/wlp \
+    && chmod -R g+rw /opt/ol/wlp
+
+# Set Path Shortcuts
+ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+    LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ol/wlp/output \
+    WLP_SKIP_MAXPERMSIZE=true
+
+# Configure Open Liberty
+RUN /opt/ol/wlp/bin/server create \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+
+# Create symlinks && set permissions for non-root user
+RUN mkdir /logs \
+    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+    && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
+    && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && ln -s /opt/ol/wlp /liberty \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /opt/ol/wlp/usr \
+    && chmod -R g+rw /opt/ol/wlp/usr \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rw /opt/ol/wlp/output \
+    && chown -R 1001:0 /opt/ol/helpers \
+    && chmod -R g+rw /opt/ol/helpers \
+    && mkdir /etc/wlp \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+
+USER 1001
+
+EXPOSE 9080 9443
+
+ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/hazelcast-client.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/hazelcast-client.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+  <network>
+    <redo-operation>true</redo-operation>
+    <discovery-strategies>
+      <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+      </discovery-strategy>
+    </discovery-strategies>
+  </network>
+</hazelcast-client>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/hazelcast-embedded.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/hazelcast-embedded.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+  <network>
+    <join>
+      <multicast enabled="false"/>
+      <tcp-ip enabled="false"/>
+      <discovery-strategies>
+        <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+        </discovery-strategy>
+      </discovery-strategies>
+    </join>
+  </network>
+</hazelcast>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/hazelcast-sessioncache.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/hazelcast-sessioncache.xml
@@ -1,0 +1,11 @@
+<server>
+  <featureManager>
+    <feature>sessionCache-1.0</feature>
+  </featureManager>
+  <httpSessionCache libraryRef="HazelcastLib">
+    <properties hazelcast.config.location="file:${shared.config.dir}/hazelcast/hazelcast.xml"/>
+  </httpSessionCache>
+  <library id="HazelcastLib">
+    <fileset dir="${shared.resource.dir}/hazelcast"/>
+  </library>
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/http-endpoint.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/http-endpoint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <variable name="HTTP_PORT" defaultValue="9080" />
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${HTTP_PORT}"/>
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/http-ssl-endpoint.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/http-ssl-endpoint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <variable name="HTTP_PORT" defaultValue="9080" />
+    <variable name="HTTPS_PORT" defaultValue="9443" />
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpsPort="${HTTPS_PORT}" httpPort="${HTTP_PORT}" />
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/iiop-endpoint.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/iiop-endpoint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <variable name="IIOP_PORT" defaultValue="2809" />
+    <iiopEndpoint id="defaultIiopEndpoint" host="${IIOP_ENDPOINT_HOST}" iiopPort="${IIOP_PORT}" />
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <variable name="IIOP_PORT" defaultValue="2809" />
+    <variable name="IIOPS_PORT" defaultValue="9402" />
+    <iiopEndpoint id="defaultIiopEndpoint" host="${IIOP_ENDPOINT_HOST}" iiopPort="${IIOP_PORT}">
+        <iiopsOptions iiopsPort="${IIOPS_PORT}" sslRef="defaultSSLConfig" />
+    </iiopEndpoint>
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/jms-endpoint.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/jms-endpoint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <variable name="JMS_PORT" defaultValue="7276" />
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsPort="${JMS_PORT}" />
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <variable name="JMSS_PORT" defaultValue="7286" />
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsSSLPort="${JMSS_PORT}" />
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/keystore.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/keystore.xml
@@ -1,0 +1,3 @@
+<server description="Default Server">
+    <keyStore id="defaultKeyStore" password="REPLACE" />
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/mp-health-check.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/mp-health-check.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>mpHealth-1.0</feature>
+    </featureManager>
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/mp-monitoring.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/mp-monitoring.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>mpMetrics-1.1</feature>
+        <feature>monitor-1.0</feature>
+    </featureManager>
+    
+    <mpMetrics authentication="false" />
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/tls.xml
+++ b/community/latest/kernel/java13/openj9/helpers/build/configuration_snippets/tls.xml
@@ -1,0 +1,5 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+</server>

--- a/community/latest/kernel/java13/openj9/helpers/build/configure.sh
+++ b/community/latest/kernel/java13/openj9/helpers/build/configure.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -eox pipefail
+
+##Define variables for XML snippets source and target paths
+WLP_INSTALL_DIR=/opt/ol/wlp
+SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
+SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
+
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
+mkdir -p ${SNIPPETS_TARGET}
+
+
+#Check for each Liberty value-add functionality
+
+# MicroProfile Health
+if [ "$MP_HEALTH_CHECK" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
+fi
+
+# MicroProfile Monitoring
+if [ "$MP_MONITORING" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
+fi
+
+# HTTP Endpoint
+if [ "$HTTP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+    cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
+  fi
+fi
+
+# Hazelcast Session Caching
+if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]
+then
+ cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
+ mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
+ cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
+fi
+
+# IIOP Endpoint
+if [ "$IIOP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+    cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
+  fi
+fi
+
+# JMS Endpoint
+if [ "$JMS_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+    cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
+  fi
+fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+  cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
+fi
+
+if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]
+then
+  if [ ! -e $keystorePath ]
+  then
+    # Generate the keystore.xml
+    export KEYSTOREPWD=$(openssl rand -base64 32)
+    sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+    cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  fi
+fi
+
+# Server start/stop to populate the /output/workarea and make subsequent server starts faster
+/opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*

--- a/community/latest/kernel/java13/openj9/helpers/runtime/docker-server.sh
+++ b/community/latest/kernel/java13/openj9/helpers/runtime/docker-server.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
+SNIPPETS_TARGET_OVERRIDES=/config/configDropins/overrides
+
+keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+
+if [ "$SSL" = "true" ] || [ "$TLS" = "true" ]
+then
+  cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET_OVERRIDES/tls.xml
+fi
+
+if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]
+then
+  if [ ! -e $keystorePath ]
+  then
+    # Generate the keystore.xml
+    export KEYSTOREPWD=$(openssl rand -base64 32)
+    sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+    cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  fi
+fi
+
+
+# Pass on to the real server run
+exec "$@"

--- a/community/latest/kernel/java13/openj9/licenses/LICENSE
+++ b/community/latest/kernel/java13/openj9/licenses/LICENSE
@@ -1,0 +1,203 @@
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and documentation
+   distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+    i) changes to the Program, and
+   ii) additions to the Program;
+
+   where such changes and/or additions to the Program originate from and are
+   distributed by that particular Contributor. A Contribution 'originates'
+   from a Contributor if it was added to the Program by such Contributor
+   itself or anyone acting on such Contributor's behalf. Contributions do not
+   include additions to the Program which: (i) are separate modules of
+   software distributed in conjunction with the Program under their own
+   license agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+  a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+  b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+  c) Recipient understands that although each Contributor grants the licenses
+     to its Contributions set forth herein, no assurances are provided by any
+     Contributor that the Program does not infringe the patent or other
+     intellectual property rights of any other entity. Each Contributor
+     disclaims any liability to Recipient for claims brought by any other
+     entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+  d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+  a) it complies with the terms and conditions of this Agreement; and
+  b) its license agreement:
+      i) effectively disclaims on behalf of all Contributors all warranties
+         and conditions, express and implied, including warranties or
+         conditions of title and non-infringement, and implied warranties or
+         conditions of merchantability and fitness for a particular purpose;
+     ii) effectively excludes on behalf of all Contributors all liability for
+         damages, including direct, indirect, special, incidental and
+         consequential damages, such as lost profits;
+    iii) states that any provisions which differ from this Agreement are
+         offered by that Contributor alone and not by any other party; and
+     iv) states that source code for the Program is available from such
+         Contributor, and informs licensees how to obtain it in a reasonable
+         manner on or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+  a) it must be made available under this Agreement; and
+  b) a copy of this Agreement must be included with each copy of the Program.
+     Contributors may not remove or alter any copyright notices contained
+     within the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if
+any, in a manner that reasonably allows subsequent Recipients to identify the
+originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor to control, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim at
+its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial in
+any resulting litigation.


### PR DESCRIPTION
Adds Java 13 community images based off of `adoptopenjdk/openjdk13-openj9:ubi-minimal-jre`.

Right now these use OpenLiberty 19.0.0.10, but Liberty won't fully support Java 13 until 19.0.0.11 at the earliest.