### PR TITLE
Fix Permission Denied issue for UBI kernel builds

### DIFF
--- a/community/latest/kernel/java11/openj9/Dockerfile.ubi
+++ b/community/latest/kernel/java11/openj9/Dockerfile.ubi
@@ -24,6 +24,7 @@ RUN microdnf -y install shadow-utils wget unzip \
     && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
     && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
     && sha1sum -c /tmp/wlp.zip.sha1 \
+    && chmod -R u+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ol \
     && rm /tmp/wlp.zip \
     && rm /tmp/wlp.zip.sha1 \

--- a/community/latest/kernel/java13/openj9/Dockerfile.ubi
+++ b/community/latest/kernel/java13/openj9/Dockerfile.ubi
@@ -24,6 +24,7 @@ RUN microdnf -y install shadow-utils wget unzip \
     && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
     && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
     && sha1sum -c /tmp/wlp.zip.sha1 \
+    && chmod -R u+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ol \
     && rm /tmp/wlp.zip \
     && rm /tmp/wlp.zip.sha1 \

--- a/community/latest/kernel/java8/ibmjava/Dockerfile.ubi
+++ b/community/latest/kernel/java8/ibmjava/Dockerfile.ubi
@@ -24,7 +24,7 @@ RUN yum -y install wget unzip \
     && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
     && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
     && sha1sum -c /tmp/wlp.zip.sha1 \
-    && chmod -R g+rwx /usr/bin \
+    && chmod -R g+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ol \
     && rm /tmp/wlp.zip \
     && rm /tmp/wlp.zip.sha1 \

--- a/community/latest/kernel/java8/ibmjava/Dockerfile.ubi
+++ b/community/latest/kernel/java8/ibmjava/Dockerfile.ubi
@@ -24,7 +24,7 @@ RUN yum -y install wget unzip \
     && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
     && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
     && sha1sum -c /tmp/wlp.zip.sha1 \
-    && chmod g+rwx /usr/bin \
+    && chmod -R g+rwx /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ol \
     && rm /tmp/wlp.zip \
     && rm /tmp/wlp.zip.sha1 \

--- a/community/latest/kernel/java8/ibmjava/Dockerfile.ubi
+++ b/community/latest/kernel/java8/ibmjava/Dockerfile.ubi
@@ -24,6 +24,7 @@ RUN yum -y install wget unzip \
     && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
     && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
     && sha1sum -c /tmp/wlp.zip.sha1 \
+    && chmod g+rwx /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ol \
     && rm /tmp/wlp.zip \
     && rm /tmp/wlp.zip.sha1 \

--- a/community/latest/kernel/java8/openj9/Dockerfile.ubi
+++ b/community/latest/kernel/java8/openj9/Dockerfile.ubi
@@ -24,6 +24,7 @@ RUN microdnf -y install shadow-utils wget unzip \
     && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
     && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
     && sha1sum -c /tmp/wlp.zip.sha1 \
+    && chmod -R u+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ol \
     && rm /tmp/wlp.zip \
     && rm /tmp/wlp.zip.sha1 \


### PR DESCRIPTION
- Travis UBI builds were seeing issues on `ppc64le` travis VMs with root user not having the ability to run unzip after it was installed by yum.
- Granted permission to the directory in each ubi latest kernel build.
- Already running build as root so the change is redundant in most environments