### PR TITLE
Add option to control SCC creation and calculate SCC size automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 There are two different Open Liberty Docker image sets available on Docker Hub:
 
 1. **Supported Images**
-    *  Our recommended set [here](https://hub.docker.com/r/openliberty/open-liberty).  These are images using Red Hat's [Universal Base Image](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) as the Operating System and are re-built daily.  
+    *  Our recommended set [here](https://hub.docker.com/r/openliberty/open-liberty).  These are images using Red Hat's [Universal Base Image](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) as the Operating System and are re-built daily.
     *  Other sets can be found [here](https://hub.docker.com/_/open-liberty).  These are re-built automatically anytime something changes in the layers below.  There are tags with different combinations of Java and Operating System versions.
 
 1. **Daily Images**
@@ -65,9 +65,21 @@ This section describes the optional enterprise functionality that can be enabled
   *  Decription: Enable OpenIdConnect Client function by adding the `openidConnectClient-1.0` feature.
   *  XML Snippet Location: [oidc.xml](/common/helpers/build/configuration_snippets/oidc.xml)
 * `OIDC_CONFIG`
-  *  Decription: Enable OpenIdConnect Client configuration to be read from environment variables.  
+  *  Decription: Enable OpenIdConnect Client configuration to be read from environment variables.
   *  XML Snippet Location: [oidc-config.xml](/common/helpers/build/configuration_snippets/oidc-config.xml)
-  *  Note: The following variables will be read:  OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL.  
+  *  Note: The following variables will be read:  OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL.
+
+## OpenJ9 Shared Class Cache (SCC)
+
+OpenJ9's SCC allows the VM to store Java classes in an optimized form that can be loaded very quickly, JIT compiled code, and profiling data. Deploying an SCC file together with your application can significantly improve start-up time. The SCC can also be shared by multiple VMs, thereby reducing total memory consumption.
+
+Open Liberty Docker images contain an SCC and (by default) add your application's specific data to the SCC at image build time when your Dockerfile invokes `RUN configure.sh`.
+
+This feature can be controlled via the following variables:
+
+* `OPENJ9_SCC` (environment variable)
+  *  Decription: If `"true"`, cache application-specific in an SCC and include it in the image. A new SCC will be created if needed, otherwise data will be added to the existing SCC.
+  *  Default: `"true"`.
 
 To customize one of the built-in XML snippets, make a copy of the snippet from Github and edit it locally. Once you have completed your changes, use the `COPY` command inside your Dockerfile to copy the snippet into `/config/configDropins/overrides`. It is important to note that you do not need to set build-arguments (`ARG`) for any customized XML snippets. The following Dockerfile snippet is an example of how you should include the customized snippet.
 

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -70,8 +70,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
-# Create a new SCC layer, args are layer size and number of iterations to run to populate it
-RUN populate_scc.sh 4m 3 \
+# Create a new SCC layer
+RUN populate_scc.sh \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -3,6 +3,7 @@ ARG LIBERTY_VERSION=20.0.0.1
 ARG LIBERTY_SHA=dfededade132ba37fabbcf07d5004773ee9f3be5
 ARG LIBERTY_BUILD_LABEL=cl200120200108-0300
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
+ARG OPENJ9_SCC=true
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \
@@ -38,7 +39,8 @@ RUN yum -y install shadow-utils wget unzip \
 ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
-    WLP_SKIP_MAXPERMSIZE=true
+    WLP_SKIP_MAXPERMSIZE=true \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
@@ -71,7 +73,7 @@ RUN mkdir /logs \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 # Create a new SCC layer
-RUN populate_scc.sh \
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk13
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk13
@@ -70,8 +70,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
-# Create a new SCC layer, args are layer size and number of iterations to run to populate it
-RUN populate_scc.sh 4m 3 \
+# Create a new SCC layer
+RUN populate_scc.sh \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk13
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk13
@@ -3,6 +3,7 @@ ARG LIBERTY_VERSION=20.0.0.1
 ARG LIBERTY_SHA=dfededade132ba37fabbcf07d5004773ee9f3be5
 ARG LIBERTY_BUILD_LABEL=cl200120200108-0300
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
+ARG OPENJ9_SCC=true
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \
@@ -38,7 +39,8 @@ RUN yum -y install shadow-utils wget unzip \
 ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
-    WLP_SKIP_MAXPERMSIZE=true
+    WLP_SKIP_MAXPERMSIZE=true \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
@@ -71,7 +73,7 @@ RUN mkdir /logs \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 # Create a new SCC layer
-RUN populate_scc.sh \
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -70,8 +70,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
-# Create a new SCC layer, args are layer size and number of iterations to run to populate it
-RUN populate_scc.sh 4m 3 \
+# Create a new SCC layer
+RUN populate_scc.sh \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -3,6 +3,7 @@ ARG LIBERTY_VERSION=20.0.0.1
 ARG LIBERTY_SHA=dfededade132ba37fabbcf07d5004773ee9f3be5
 ARG LIBERTY_BUILD_LABEL=cl200120200108-0300
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
+ARG OPENJ9_SCC=true
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \
@@ -38,7 +39,8 @@ RUN yum -y install shadow-utils wget unzip \
 ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
-    WLP_SKIP_MAXPERMSIZE=true
+    WLP_SKIP_MAXPERMSIZE=true \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
@@ -71,7 +73,7 @@ RUN mkdir /logs \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 # Create a new SCC layer
-RUN populate_scc.sh \
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -1,9 +1,9 @@
-
 FROM adoptopenjdk:8-jre-openj9
 ARG LIBERTY_VERSION=20.0.0.1
 ARG LIBERTY_SHA=dfededade132ba37fabbcf07d5004773ee9f3be5
 ARG LIBERTY_BUILD_LABEL=cl200120200108-0300
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
+ARG OPENJ9_SCC=true
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \
@@ -34,7 +34,8 @@ RUN apt-get update \
 ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
-    WLP_SKIP_MAXPERMSIZE=true
+    WLP_SKIP_MAXPERMSIZE=true \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
@@ -67,7 +68,7 @@ RUN mkdir /logs \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 # Create a new SCC layer
-RUN populate_scc.sh \
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -66,8 +66,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
-# Create a new SCC layer, args are layer size and number of iterations to run to populate it
-RUN populate_scc.sh 4m 3 \
+# Create a new SCC layer
+RUN populate_scc.sh \
     && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/kernel/helpers/build/configure.sh
+++ b/releases/latest/kernel/helpers/build/configure.sh
@@ -78,4 +78,7 @@ then
 fi
 
 # Create a new SCC layer
-populate_scc.sh
+if [ "$OPENJ9_SCC" == "true" ]
+then
+  populate_scc.sh
+fi

--- a/releases/latest/kernel/helpers/build/configure.sh
+++ b/releases/latest/kernel/helpers/build/configure.sh
@@ -77,5 +77,5 @@ then
   fi
 fi
 
-# Create a new SCC layer, args are layer size and number of iterations to run to populate it
-populate_scc.sh 8m 3
+# Create a new SCC layer
+populate_scc.sh

--- a/releases/latest/kernel/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel/helpers/build/populate_scc.sh
@@ -1,8 +1,47 @@
 #!/bin/bash
 set -Eeox pipefail
 
-SCC_SIZE="$1" # Size of the SCC layer
-ITERATIONS="$2" # Number of iterations to run to populate it
+SCC_SIZE="80m"  # Default size of the SCC layer.
+ITERATIONS=3    # Number of iterations to run to populate it.
+TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
+
+while getopts ":i:s:tdh" OPT
+do
+  case "$OPT" in
+    i)
+      ITERATIONS="$OPTARG"
+      ;;
+    s)
+      [ "${OPTARG: -1}" == "m" ] || ( echo "Missing m suffix." && exit 1 )
+      SCC_SIZE="$OPTARG"
+      ;;
+    t)
+      TRIM_SCC=yes
+      ;;
+    d)
+      TRIM_SCC=no
+      ;;
+    h)
+      echo \
+"Usage: $0 [-i iterations] [-s size] [-t] [-d]
+  -i <iterations> Number of iterations to run to populate the SCC. (Default: $ITERATIONS)
+  -s <size>       Size of the SCC in megabytes (m suffix required). (Default: $SCC_SIZE)
+  -t              Trim the SCC to eliminate most of the free space, if any.
+  -d              Don't trim the SCC.
+
+  Trimming enabled=$TRIM_SCC"
+      exit 1
+      ;;
+    \?)
+      echo "Unrecognized option: $OPTARG" 1>&2
+      exit 1
+      ;;
+    :)
+      echo "Missing argument for option: $OPTARG" 1>&2
+      exit 1
+      ;;
+  esac
+done
 
 # Make sure the following Java commands don't disturb our class cache until we're ready to populate it
 # by unsetting IBM_JAVA_OPTIONS if it is currently defined.
@@ -12,13 +51,43 @@ unset IBM_JAVA_OPTIONS
 # `server start` to do it, which will lead to problems because multiple JVMs will be started.
 java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
 
+if [ $TRIM_SCC == yes ]
+then
+  echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
+  # Populate the newly created class cache layer.
+  export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  # Find out how full it is.
+  unset IBM_JAVA_OPTIONS
+  FULL=`( java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,printTopLayerStats || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
+  echo "SCC layer is $FULL% full. Destroying layer."
+  # Destroy the layer once we know roughly how much space we need.
+  java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true
+  # Remove the m suffix.
+  SCC_SIZE="${SCC_SIZE:0:-1}"
+  # Calculate the new size based on how full the layer was (rounded to nearest m).
+  SCC_SIZE=`awk "BEGIN {print int($SCC_SIZE * $FULL / 100.0 + 0.5)}"`
+  # Make sure size is >0.
+  [ $SCC_SIZE -eq 0 ] && SCC_SIZE=1
+  # Add the m suffix back.
+  SCC_SIZE="${SCC_SIZE}m"
+  echo "Re-creating layer with size $SCC_SIZE."
+  # Recreate the layer with the new size.
+  java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
+fi
+
 # Populate the newly created class cache layer.
 export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
 
-# Server start/stop to populate the /output/workarea and make subsequent server starts faster
+# Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
   /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
 done
 
 rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ol/wlp/output/*
+
+unset IBM_JAVA_OPTIONS
+# Tell the user how full the final layer is.
+FULL=`( java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,printTopLayerStats || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
+echo "SCC layer is $FULL% full."


### PR DESCRIPTION
This PR makes two changes:

- Introduces a build arg `OPENJ9_SCC` to control whether or not we create and include an SCC in the image. By default the kernel and test images in this tree will include an SCC, but dependent images will not unless they define `OPENJ9_SCC=true` before calling `configure.sh`.
- Automates the sizing of the SCC by creating an initial extra large SCC and resizing it to eliminate free space. Super simple apps like `test-stock-quote` will still create SCC layers with a noticeable amount of free space because of the way the SCC is organized, but real-world apps should behave as expected.