### PR TITLE
Update README links for new directory setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,30 +43,30 @@ This section describes the optional enterprise functionality that can be enabled
 
 * `HTTP_ENDPOINT`
   *  Decription: Add configuration properties for an HTTP endpoint.
-  *  XML Snippet Location: [http-ssl-endpoint.xml](/common/helpers/build/configuration_snippets/http-ssl-endpoint.xml) when SSL is enabled. Otherwise [http-endpoint.xml](/common/helpers/build/configuration_snippets/http-endpoint.xml)
+  *  XML Snippet Location: [http-ssl-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/http-ssl-endpoint.xml) when SSL is enabled. Otherwise [http-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/http-endpoint.xml)
 * `MP_HEALTH_CHECK`
   *  Decription: Check the health of the environment using Liberty feature `mpHealth-1.0` (implements [MicroProfile Health](https://microprofile.io/project/eclipse/microprofile-health)).
-  *  XML Snippet Location: [mp-health-check.xml](/common/helpers/build/configuration_snippets/mp-health-check.xml)
+  *  XML Snippet Location: [mp-health-check.xml](/releases/latest/kernel/helpers/build/configuration_snippets/mp-health-check.xml)
 * `MP_MONITORING`
   *  Decription: Monitor the server runtime environment and application metrics by using Liberty features `mpMetrics-1.1` (implements [Microprofile Metrics](https://microprofile.io/project/eclipse/microprofile-metrics)) and `monitor-1.0`.
-  *  XML Snippet Location: [mp-monitoring.xml](/common/helpers/build/configuration_snippets/mp-monitoring.xml)
+  *  XML Snippet Location: [mp-monitoring.xml](/releases/latest/kernel/helpers/build/configuration_snippets/mp-monitoring.xml)
   *  Note: With this option, `/metrics` endpoint is configured without authentication to support the environments that do not yet support scraping secured endpoints.
 * `TLS` or `SSL` (SSL is being deprecated)
   *  Decription: Enable Transport Security in Liberty by adding the `transportSecurity-1.0` feature (includes support for SSL).
-  *  XML Snippet Location:  [keystore.xml](/common/helpers/build/configuration_snippets/keystore.xml).
+  *  XML Snippet Location:  [keystore.xml](/releases/latest/kernel/helpers/build/configuration_snippets/keystore.xml).
 * `IIOP_ENDPOINT`
   *  Decription: Add configuration properties for an IIOP endpoint.
-  *  XML Snippet Location: [iiop-ssl-endpoint.xml](/common/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml) when SSL is enabled. Otherwise, [iiop-endpoint.xml](/common/helpers/build/configuration_snippets/iiop-endpoint.xml).
+  *  XML Snippet Location: [iiop-ssl-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml) when SSL is enabled. Otherwise, [iiop-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/iiop-endpoint.xml).
   *  Note: If using this option, `env.IIOP_ENDPOINT_HOST` environment variable should be set to the server's host. See [IIOP endpoint configuration](https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.liberty.autogen.base.doc/ae/rwlp_config_orb.html#iiopEndpoint) for more details.
 * `JMS_ENDPOINT`
   *  Decription: Add configuration properties for an JMS endpoint.
-  *  XML Snippet Location: [jms-ssl-endpoint.xml](/common/helpers/build/configuration_snippets/jms-ssl-endpoint.xml) when SSL is enabled. Otherwise, [jms-endpoint.xml](/common/helpers/build/configuration_snippets/jms-endpoint.xml)
+  *  XML Snippet Location: [jms-ssl-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_ssl_endpoint.xml) when SSL is enabled. Otherwise, [jms-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_endpoint.xml)
 * `OIDC`
   *  Decription: Enable OpenIdConnect Client function by adding the `openidConnectClient-1.0` feature.
-  *  XML Snippet Location: [oidc.xml](/common/helpers/build/configuration_snippets/oidc.xml)
+  *  XML Snippet Location: [oidc.xml](/releases/latest/kernel/helpers/build/configuration_snippets/oidc.xml)
 * `OIDC_CONFIG`
   *  Decription: Enable OpenIdConnect Client configuration to be read from environment variables.
-  *  XML Snippet Location: [oidc-config.xml](/common/helpers/build/configuration_snippets/oidc-config.xml)
+  *  XML Snippet Location: [oidc-config.xml](/releases/latest/kernel/helpers/build/configuration_snippets/oidc-config.xml)
   *  Note: The following variables will be read:  OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL.
 
 ## OpenJ9 Shared Class Cache (SCC)
@@ -119,7 +119,7 @@ For more information regarding the configuration of Open Liberty's logging capab
 
 ### Session Caching
 
-The Liberty session caching feature builds on top of an existing technology called JCache (JSR 107), which provides an API for distributed in-memory caching. There are several providers of JCache implementations. One example is [Hazelcast In-Memory Data Grid](https://hazelcast.org/). Enabling Hazelcast session caching retrieves the Hazelcast client libraries from the [hazelcast/hazelcast](https://hub.docker.com/r/hazelcast/hazelcast/) Docker image, configures Hazelcast by copying a sample [hazelcast.xml](/common/helpers/build/configuration_snippets/), and configures the Liberty server feature [sessionCache-1.0](https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_admin_session_persistence_jcache.html) by including the XML snippet [hazelcast-sessioncache.xml](/common/helpers/build/configuration_snippets/hazelcast-sessioncache.xml). By default, the [Hazelcast Discovery Plugin for Kubernetes](https://github.com/hazelcast/hazelcast-kubernetes) will auto-discover its peers within the same Kubernetes namespace. To enable this functionality, the Docker image author can include the following Dockerfile snippet, and choose from either client-server or embedded [topology](https://docs.hazelcast.org/docs/latest-development/manual/html/Hazelcast_Overview/Hazelcast_Topology.html).
+The Liberty session caching feature builds on top of an existing technology called JCache (JSR 107), which provides an API for distributed in-memory caching. There are several providers of JCache implementations. One example is [Hazelcast In-Memory Data Grid](https://hazelcast.org/). Enabling Hazelcast session caching retrieves the Hazelcast client libraries from the [hazelcast/hazelcast](https://hub.docker.com/r/hazelcast/hazelcast/) Docker image, configures Hazelcast by copying a sample [hazelcast.xml](/releases/latest/kernel/helpers/build/configuration_snippets/), and configures the Liberty server feature [sessionCache-1.0](https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_admin_session_persistence_jcache.html) by including the XML snippet [hazelcast-sessioncache.xml](/releases/latest/kernel/helpers/build/configuration_snippets/hazelcast-sessioncache.xml). By default, the [Hazelcast Discovery Plugin for Kubernetes](https://github.com/hazelcast/hazelcast-kubernetes) will auto-discover its peers within the same Kubernetes namespace. To enable this functionality, the Docker image author can include the following Dockerfile snippet, and choose from either client-server or embedded [topology](https://docs.hazelcast.org/docs/latest-development/manual/html/Hazelcast_Overview/Hazelcast_Topology.html).
 
 ```dockerfile
 ### Hazelcast Session Caching ###
@@ -137,9 +137,3 @@ ARG HZ_SESSION_CACHE=client
 RUN configure.sh
 ```
 
-## Updating common files
-
-Currently the `common` folder contains the `docker-server` and `README.md` files. When making changes to these files first make
-the changes in `common` and then run `sync-master.sh` to copy these files to the directories the files need to be
-in for the Docker build. All the files need to be checked into git. Docker won't allow you to copy files from
-the parent directory structure, so this allows us to update once, rather than having to update in multiple locations.

--- a/README.md
+++ b/README.md
@@ -61,13 +61,6 @@ This section describes the optional enterprise functionality that can be enabled
 * `JMS_ENDPOINT`
   *  Decription: Add configuration properties for an JMS endpoint.
   *  XML Snippet Location: [jms-ssl-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_ssl_endpoint.xml) when SSL is enabled. Otherwise, [jms-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_endpoint.xml)
-* `OIDC`
-  *  Decription: Enable OpenIdConnect Client function by adding the `openidConnectClient-1.0` feature.
-  *  XML Snippet Location: [oidc.xml](/releases/latest/kernel/helpers/build/configuration_snippets/oidc.xml)
-* `OIDC_CONFIG`
-  *  Decription: Enable OpenIdConnect Client configuration to be read from environment variables.
-  *  XML Snippet Location: [oidc-config.xml](/releases/latest/kernel/helpers/build/configuration_snippets/oidc-config.xml)
-  *  Note: The following variables will be read:  OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL.
 
 ## OpenJ9 Shared Class Cache (SCC)
 


### PR DESCRIPTION
* Updates dead links to point to `releases/latest/kernel/helpers/build/configuration_snippets/...` instead of `common/helpers/build/configuration_snippets/...`.
* Removed reference to helper file for openIdConnectClient as the files no longer exist. If this is something that *should* be there then I can find the file and include it in this PR.

Fixes #138 