### PR TITLE
Adding verbose option for configure.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,21 @@ COPY --chown=1001:0  server.xml /config/
 # Optional functionality
 ARG SSL=true
 ARG MP_MONITORING=true
+ARG VERBOSE=true
 
 # This script will add the requested XML snippets and grow image to be fit-for-purpose
-RUN configure.sh
+RUN if [ -n "$VERBOSE" ] && [ "$VERBOSE" = "true" ]; then \
+		configure.sh; \
+	else \
+		bash -c "configure.sh &> /dev/null"; \
+	fi
 ```
 
 This will result in a Docker image that has your application and configuration pre-loaded, which means you can spawn new fully-configured containers at any time.
 
 ## Enterprise Functionality
 
-This section describes the optional enterprise functionality that can be enabled via the Dockerfile during `build` time, by setting particular build-arguments (`ARG`) and calling `RUN configure.sh`.  Each of these options trigger the inclusion of specific configuration via XML snippets, described below:
+This section describes the optional enterprise functionality that can be enabled via the Dockerfile during `build` time, by setting particular build-arguments (`ARG`).  Each of these options trigger the inclusion of specific configuration via XML snippets (except for `VERBOSE`), described below:
 
 * `HTTP_ENDPOINT`
   *  Decription: Add configuration properties for an HTTP endpoint.
@@ -61,12 +66,14 @@ This section describes the optional enterprise functionality that can be enabled
 * `JMS_ENDPOINT`
   *  Decription: Add configuration properties for an JMS endpoint.
   *  XML Snippet Location: [jms-ssl-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_ssl_endpoint.xml) when SSL is enabled. Otherwise, [jms-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_endpoint.xml)
+* `VERBOSE`
+	* Description: Outputs the commands and results to stdout from `configure.sh`. Otherwise no output is produced from `configure.sh`.
 
 ## OpenJ9 Shared Class Cache (SCC)
 
 OpenJ9's SCC allows the VM to store Java classes in an optimized form that can be loaded very quickly, JIT compiled code, and profiling data. Deploying an SCC file together with your application can significantly improve start-up time. The SCC can also be shared by multiple VMs, thereby reducing total memory consumption.
 
-Open Liberty Docker images contain an SCC and (by default) add your application's specific data to the SCC at image build time when your Dockerfile invokes `RUN configure.sh`.
+Open Liberty Docker images contain an SCC and (by default) add your application's specific data to the SCC at image build time when your Dockerfile invokes `configure.sh`.
 
 This feature can be controlled via the following variables:
 
@@ -127,6 +134,10 @@ ARG HZ_SESSION_CACHE=client
 #ENV JAVA_TOOL_OPTIONS="-Dhazelcast.jcache.provider.type=server ${JAVA_TOOL_OPTIONS}"
 
 ## This script will add the requested XML snippets and grow image to be fit-for-purpose
-RUN configure.sh
+RUN if [ -n "$VERBOSE" ] && [ "$VERBOSE" = "true" ]; then \
+		configure.sh; \
+	else \
+		bash -c "configure.sh &> /dev/null"; \
+	fi
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ FROM open-liberty:kernel
 COPY --chown=1001:0  Sample1.war /config/dropins/
 COPY --chown=1001:0  server.xml /config/
 
+# Default setting for the verbose option
+ARG VERBOSE=false
+
 # Optional functionality
 ARG SSL=true
 ARG MP_MONITORING=true
@@ -62,7 +65,7 @@ This section describes the optional enterprise functionality that can be enabled
   *  Decription: Add configuration properties for an JMS endpoint.
   *  XML Snippet Location: [jms-ssl-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_ssl_endpoint.xml) when SSL is enabled. Otherwise, [jms-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_endpoint.xml)
 * `VERBOSE`
-	* Description: Outputs the commands and results to stdout from `configure.sh`. Otherwise no output is produced from `configure.sh`.
+	* Description: When set to `true` it outputs the commands and results to stdout from `configure.sh`. Default setting is `false`.
 
 ## OpenJ9 Shared Class Cache (SCC)
 
@@ -123,6 +126,9 @@ COPY --from=hazelcast/hazelcast --chown=1001:0 /opt/hazelcast/lib/*.jar /opt/ol/
 
 # Instruct configure.sh to copy the client topology hazelcast.xml
 ARG HZ_SESSION_CACHE=client
+
+# Default setting for the verbose option
+ARG VERBOSE=false
 
 # Instruct configure.sh to copy the embedded topology hazelcast.xml and set the required system property
 #ARG HZ_SESSION_CACHE=embedded

--- a/README.md
+++ b/README.md
@@ -30,21 +30,16 @@ COPY --chown=1001:0  server.xml /config/
 # Optional functionality
 ARG SSL=true
 ARG MP_MONITORING=true
-ARG VERBOSE=true
 
 # This script will add the requested XML snippets and grow image to be fit-for-purpose
-RUN if [ -n "$VERBOSE" ] && [ "$VERBOSE" = "true" ]; then \
-		configure.sh; \
-	else \
-		bash -c "configure.sh &> /dev/null"; \
-	fi
+RUN configure.sh
 ```
 
 This will result in a Docker image that has your application and configuration pre-loaded, which means you can spawn new fully-configured containers at any time.
 
 ## Enterprise Functionality
 
-This section describes the optional enterprise functionality that can be enabled via the Dockerfile during `build` time, by setting particular build-arguments (`ARG`).  Each of these options trigger the inclusion of specific configuration via XML snippets (except for `VERBOSE`), described below:
+This section describes the optional enterprise functionality that can be enabled via the Dockerfile during `build` time, by setting particular build-arguments (`ARG`) and calling `RUN configure.sh`.  Each of these options trigger the inclusion of specific configuration via XML snippets (except for `VERBOSE`), described below:
 
 * `HTTP_ENDPOINT`
   *  Decription: Add configuration properties for an HTTP endpoint.
@@ -73,7 +68,7 @@ This section describes the optional enterprise functionality that can be enabled
 
 OpenJ9's SCC allows the VM to store Java classes in an optimized form that can be loaded very quickly, JIT compiled code, and profiling data. Deploying an SCC file together with your application can significantly improve start-up time. The SCC can also be shared by multiple VMs, thereby reducing total memory consumption.
 
-Open Liberty Docker images contain an SCC and (by default) add your application's specific data to the SCC at image build time when your Dockerfile invokes `configure.sh`.
+Open Liberty Docker images contain an SCC and (by default) add your application's specific data to the SCC at image build time when your Dockerfile invokes `RUN configure.sh`.
 
 This feature can be controlled via the following variables:
 
@@ -134,10 +129,6 @@ ARG HZ_SESSION_CACHE=client
 #ENV JAVA_TOOL_OPTIONS="-Dhazelcast.jcache.provider.type=server ${JAVA_TOOL_OPTIONS}"
 
 ## This script will add the requested XML snippets and grow image to be fit-for-purpose
-RUN if [ -n "$VERBOSE" ] && [ "$VERBOSE" = "true" ]; then \
-		configure.sh; \
-	else \
-		bash -c "configure.sh &> /dev/null"; \
-	fi
+RUN configure.sh
 ```
 

--- a/build/test-pet-clinic/Dockerfile
+++ b/build/test-pet-clinic/Dockerfile
@@ -13,8 +13,4 @@ COPY --chown=1001:0 server.xml /config/server.xml
 COPY --from=staging /staging/lib.index.cache /lib.index.cache
 COPY --from=staging /staging/myThinApp.jar /config/dropins/spring/myThinApp.jar
 
-RUN if [ -n "$VERBOSE" ] && [ "$VERBOSE" = "true" ]; then \
-		configure.sh; \
-	else \
-		bash -c "configure.sh &> /dev/null"; \
-	fi
+RUN configure.sh

--- a/build/test-pet-clinic/Dockerfile
+++ b/build/test-pet-clinic/Dockerfile
@@ -13,4 +13,8 @@ COPY --chown=1001:0 server.xml /config/server.xml
 COPY --from=staging /staging/lib.index.cache /lib.index.cache
 COPY --from=staging /staging/myThinApp.jar /config/dropins/spring/myThinApp.jar
 
-RUN configure.sh
+RUN if [ -n "$VERBOSE" ] && [ "$VERBOSE" = "true" ]; then \
+		configure.sh; \
+	else \
+		bash -c "configure.sh &> /dev/null"; \
+	fi

--- a/build/test-pet-clinic/Dockerfile
+++ b/build/test-pet-clinic/Dockerfile
@@ -13,4 +13,6 @@ COPY --chown=1001:0 server.xml /config/server.xml
 COPY --from=staging /staging/lib.index.cache /lib.index.cache
 COPY --from=staging /staging/myThinApp.jar /config/dropins/spring/myThinApp.jar
 
+ARG VERBOSE=false
+
 RUN configure.sh

--- a/build/test-stock-quote/Dockerfile
+++ b/build/test-stock-quote/Dockerfile
@@ -4,4 +4,6 @@ FROM ${IMAGE}
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 stock-quote-1.0-SNAPSHOT.war /config/apps/StockQuote.war
 
+ARG VERBOSE=false
+
 RUN configure.sh 

--- a/build/test-stock-quote/Dockerfile
+++ b/build/test-stock-quote/Dockerfile
@@ -4,8 +4,4 @@ FROM ${IMAGE}
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 stock-quote-1.0-SNAPSHOT.war /config/apps/StockQuote.war
 
-RUN if [ -n "$VERBOSE" ] && [ "$VERBOSE" = "true" ]; then \
-		configure.sh; \
-	else \
-		bash -c "configure.sh &> /dev/null"; \
-	fi
+RUN configure.sh 

--- a/build/test-stock-quote/Dockerfile
+++ b/build/test-stock-quote/Dockerfile
@@ -4,4 +4,8 @@ FROM ${IMAGE}
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 stock-quote-1.0-SNAPSHOT.war /config/apps/StockQuote.war
 
-RUN configure.sh
+RUN if [ -n "$VERBOSE" ] && [ "$VERBOSE" = "true" ]; then \
+		configure.sh; \
+	else \
+		bash -c "configure.sh &> /dev/null"; \
+	fi

--- a/build/test-stock-trader/Dockerfile
+++ b/build/test-stock-trader/Dockerfile
@@ -4,8 +4,4 @@ FROM ${IMAGE}
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 trader-1.0-SNAPSHOT.war /config/apps/TraderUI.war
 
-RUN if [ -n "$VERBOSE" ] && [ "$VERBOSE" = "true" ]; then \
-		configure.sh; \
-	else \
-		bash -c "configure.sh &> /dev/null"; \
-	fi
+RUN configure.sh

--- a/build/test-stock-trader/Dockerfile
+++ b/build/test-stock-trader/Dockerfile
@@ -4,4 +4,6 @@ FROM ${IMAGE}
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 trader-1.0-SNAPSHOT.war /config/apps/TraderUI.war
 
+ARG VERBOSE=false
+
 RUN configure.sh

--- a/build/test-stock-trader/Dockerfile
+++ b/build/test-stock-trader/Dockerfile
@@ -4,4 +4,8 @@ FROM ${IMAGE}
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 trader-1.0-SNAPSHOT.war /config/apps/TraderUI.war
 
-RUN configure.sh
+RUN if [ -n "$VERBOSE" ] && [ "$VERBOSE" = "true" ]; then \
+		configure.sh; \
+	else \
+		bash -c "configure.sh &> /dev/null"; \
+	fi

--- a/releases/19.0.0.12/kernel/helpers/build/configure.sh
+++ b/releases/19.0.0.12/kernel/helpers/build/configure.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -Eeox pipefail
+set -Eeo pipefail
+
+if [ "$VERBOSE" == "true" ]; then
+	set -Eeox pipefail
+fi 
 
 ##Define variables for XML snippets source and target paths
 WLP_INSTALL_DIR=/opt/ol/wlp

--- a/releases/19.0.0.9/javaee8/helpers/build/configure.sh
+++ b/releases/19.0.0.9/javaee8/helpers/build/configure.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -Eeox pipefail
+set -Eeo pipefail
+
+if [ "$VERBOSE" == "true" ]; then
+	set -Eeox pipefail
+fi 
 
 ##Define variables for XML snippets source and target paths
 WLP_INSTALL_DIR=/opt/ol/wlp

--- a/releases/19.0.0.9/kernel/helpers/build/configure.sh
+++ b/releases/19.0.0.9/kernel/helpers/build/configure.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -Eeox pipefail
+set -Eeo pipefail
+
+if [ "$VERBOSE" == "true" ]; then
+	set -Eeox pipefail
+fi 
 
 ##Define variables for XML snippets source and target paths
 WLP_INSTALL_DIR=/opt/ol/wlp

--- a/releases/19.0.0.9/webProfile8/helpers/build/configure.sh
+++ b/releases/19.0.0.9/webProfile8/helpers/build/configure.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -Eeox pipefail
+set -Eeo pipefail
+
+if [ "$VERBOSE" == "true" ]; then
+	set -Eeox pipefail
+fi 
 
 ##Define variables for XML snippets source and target paths
 WLP_INSTALL_DIR=/opt/ol/wlp

--- a/releases/latest/kernel/helpers/build/configure.sh
+++ b/releases/latest/kernel/helpers/build/configure.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -Eeox pipefail
+set -Eeo pipefail
+
+if [ "$VERBOSE" == "true" ]; then
+	set -Eeox pipefail
+fi 
 
 ##Define variables for XML snippets source and target paths
 WLP_INSTALL_DIR=/opt/ol/wlp

--- a/releases/latest/kernel/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel/helpers/build/populate_scc.sh
@@ -54,9 +54,9 @@ unset IBM_JAVA_OPTIONS
 # Explicity create a class cache layer for this image layer here rather than allowing
 # `server start` to do it, which will lead to problems because multiple JVMs will be started.
 if [ "$VERBOSE" == "true" ]; then
-	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version &> /dev/null
-else
 	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
+else
+	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version &> /dev/null
 fi
 
 if [ $TRIM_SCC == yes ]
@@ -71,9 +71,9 @@ then
   echo "SCC layer is $FULL% full. Destroying layer."
   # Destroy the layer once we know roughly how much space we need.
   if [ "$VERBOSE" == "true" ]; then
-  	(java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true) &> /dev/null
+  	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true
   else 
-	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true
+	(java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true) &> /dev/null
   fi
   # Remove the m suffix.
   SCC_SIZE="${SCC_SIZE:0:-1}"
@@ -86,9 +86,9 @@ then
   echo "Re-creating layer with size $SCC_SIZE."
   # Recreate the layer with the new size.
   if [ "$VERBOSE" == "true" ]; then
-  	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version &> /dev/null
-  else
   	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
+  else
+  	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version &> /dev/null
   fi
 fi
 

--- a/releases/latest/kernel/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel/helpers/build/populate_scc.sh
@@ -53,7 +53,11 @@ unset IBM_JAVA_OPTIONS
 
 # Explicity create a class cache layer for this image layer here rather than allowing
 # `server start` to do it, which will lead to problems because multiple JVMs will be started.
-java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version &> /dev/null
+if [ "$VERBOSE" == "true" ]; then
+	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version &> /dev/null
+else
+	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
+fi
 
 if [ $TRIM_SCC == yes ]
 then
@@ -66,7 +70,11 @@ then
   FULL=`( java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,printTopLayerStats || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
   echo "SCC layer is $FULL% full. Destroying layer."
   # Destroy the layer once we know roughly how much space we need.
-  (java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true) &> /dev/null
+  if [ "$VERBOSE" == "true" ]; then
+  	(java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true) &> /dev/null
+  else 
+	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true
+  fi
   # Remove the m suffix.
   SCC_SIZE="${SCC_SIZE:0:-1}"
   # Calculate the new size based on how full the layer was (rounded to nearest m).
@@ -77,8 +85,13 @@ then
   SCC_SIZE="${SCC_SIZE}m"
   echo "Re-creating layer with size $SCC_SIZE."
   # Recreate the layer with the new size.
-  java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version &> /dev/null
+  if [ "$VERBOSE" == "true" ]; then
+  	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version &> /dev/null
+  else
+  	java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
+  fi
 fi
+
 
 # Populate the newly created class cache layer.
 export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"


### PR DESCRIPTION
* Changes the directions for the Dockerfile in the README so there is no output from configure.sh unless the user specifies the `ARG` `VERBOSE` to be `true`
* Issue #141 