### PR TITLE
Adding verbose option for configure.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This section describes the optional enterprise functionality that can be enabled
   *  Decription: Add configuration properties for an JMS endpoint.
   *  XML Snippet Location: [jms-ssl-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_ssl_endpoint.xml) when SSL is enabled. Otherwise, [jms-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_endpoint.xml)
 * `VERBOSE`
-  *  Description: When set to true it outputs the commands and results to stdout from configure.sh. Otherwise, default setting is false and configure.sh is silenced.
+  *  Description: When set to `true` it outputs the commands and results to stdout from `configure.sh`. Otherwise, default setting is `false` and `configure.sh` is silenced.
 
 ## OpenJ9 Shared Class Cache (SCC)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ FROM open-liberty:kernel
 COPY --chown=1001:0  Sample1.war /config/dropins/
 COPY --chown=1001:0  server.xml /config/
 
+# Default setting for the verbose option
+ARG VERBOSE=false
+
 # Optional functionality
 ARG SSL=true
 ARG MP_MONITORING=true
@@ -39,7 +42,7 @@ This will result in a Docker image that has your application and configuration p
 
 ## Enterprise Functionality
 
-This section describes the optional enterprise functionality that can be enabled via the Dockerfile during `build` time, by setting particular build-arguments (`ARG`) and calling `RUN configure.sh`.  Each of these options trigger the inclusion of specific configuration via XML snippets, described below:
+This section describes the optional enterprise functionality that can be enabled via the Dockerfile during `build` time, by setting particular build-arguments (`ARG`) and calling `RUN configure.sh`.  Each of these options trigger the inclusion of specific configuration via XML snippets (except for `VERBOSE`), described below:
 
 * `HTTP_ENDPOINT`
   *  Decription: Add configuration properties for an HTTP endpoint.
@@ -61,6 +64,8 @@ This section describes the optional enterprise functionality that can be enabled
 * `JMS_ENDPOINT`
   *  Decription: Add configuration properties for an JMS endpoint.
   *  XML Snippet Location: [jms-ssl-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_ssl_endpoint.xml) when SSL is enabled. Otherwise, [jms-endpoint.xml](/releases/latest/kernel/helpers/build/configuration_snippets/jms_endpoint.xml)
+* `VERBOSE`
+  *  Description: When set to true it outputs the commands and results to stdout from configure.sh. Otherwise, default setting is false and configure.sh is silenced.
 
 ## OpenJ9 Shared Class Cache (SCC)
 
@@ -121,6 +126,9 @@ COPY --from=hazelcast/hazelcast --chown=1001:0 /opt/hazelcast/lib/*.jar /opt/ol/
 
 # Instruct configure.sh to copy the client topology hazelcast.xml
 ARG HZ_SESSION_CACHE=client
+
+# Default setting for the verbose option
+ARG VERBOSE=false
 
 # Instruct configure.sh to copy the embedded topology hazelcast.xml and set the required system property
 #ARG HZ_SESSION_CACHE=embedded

--- a/build/test-pet-clinic/Dockerfile
+++ b/build/test-pet-clinic/Dockerfile
@@ -13,4 +13,6 @@ COPY --chown=1001:0 server.xml /config/server.xml
 COPY --from=staging /staging/lib.index.cache /lib.index.cache
 COPY --from=staging /staging/myThinApp.jar /config/dropins/spring/myThinApp.jar
 
+ARG VERBOSE=false
+
 RUN configure.sh

--- a/build/test-stock-quote/Dockerfile
+++ b/build/test-stock-quote/Dockerfile
@@ -4,4 +4,6 @@ FROM ${IMAGE}
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 stock-quote-1.0-SNAPSHOT.war /config/apps/StockQuote.war
 
+ARG VERBOSE=false
+
 RUN configure.sh

--- a/build/test-stock-trader/Dockerfile
+++ b/build/test-stock-trader/Dockerfile
@@ -4,4 +4,6 @@ FROM ${IMAGE}
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 trader-1.0-SNAPSHOT.war /config/apps/TraderUI.war
 
+ARG VERBOSE=false
+
 RUN configure.sh

--- a/releases/19.0.0.12/kernel/helpers/build/configure.sh
+++ b/releases/19.0.0.12/kernel/helpers/build/configure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
 set -Eeox pipefail
 
 ##Define variables for XML snippets source and target paths

--- a/releases/19.0.0.9/javaee8/helpers/build/configure.sh
+++ b/releases/19.0.0.9/javaee8/helpers/build/configure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
 set -Eeox pipefail
 
 ##Define variables for XML snippets source and target paths

--- a/releases/19.0.0.9/kernel/helpers/build/configure.sh
+++ b/releases/19.0.0.9/kernel/helpers/build/configure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
 set -Eeox pipefail
 
 ##Define variables for XML snippets source and target paths

--- a/releases/19.0.0.9/webProfile8/helpers/build/configure.sh
+++ b/releases/19.0.0.9/webProfile8/helpers/build/configure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
 set -Eeox pipefail
 
 ##Define variables for XML snippets source and target paths

--- a/releases/latest/kernel/helpers/build/configure.sh
+++ b/releases/latest/kernel/helpers/build/configure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
 set -Eeox pipefail
 
 ##Define variables for XML snippets source and target paths

--- a/releases/latest/kernel/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel/helpers/build/populate_scc.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
 set -Eeox pipefail
 
 SCC_SIZE="80m"  # Default size of the SCC layer.


### PR DESCRIPTION
* Redirects the output from the configure scripts based on the user specifies the build argument `VERBOSE`
* If the user sets `VERBOSE` to `true` all output from configure.sh is outputted, otherwise it is silenced.
* Changes the directions for the `Dockerfile` in the `README` to include the default `ARG VERBOSE` 
* Issue #141