### PR TITLE
Make  SEC_TLS_TRUSTDEFAULTCERTS in 20.0.0.3 release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,12 @@
 
 ## TLS certificate configuration
 
-### Automatically trust known certificate authorities
+### Automatically trust known certificate authorities (`20.0.0.3+`)
 
 To enable trust certificates from known certificate authorities `SEC_TLS_TRUSTDEFAULTCERTS` environment variable can be set.
 Default value is `false`. If set to true, then the default certificates are used in addition to the configured truststore file to establish trust.
 
-### Providing custom certificates
+### Providing custom certificates (`20.0.0.3+`)
 
 It is possible to provide custom PEM certifacates by mounting the files into the container. Files that will be imported are `tls.key`, `tls.crt` and `ca.crt`.
 

--- a/releases/20.0.0.3/kernel/helpers/build/configuration_snippets/trustDefault.xml
+++ b/releases/20.0.0.3/kernel/helpers/build/configuration_snippets/trustDefault.xml
@@ -1,3 +1,4 @@
 <server description="Default Server">
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+    <ssl id="defaultSSLConfig" trustDefaultCerts="${SEC_TLS_TRUSTDEFAULTCERTS}" />
+    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="false"/>
 </server>

--- a/releases/20.0.0.3/kernel/helpers/build/configuration_snippets/truststore.xml
+++ b/releases/20.0.0.3/kernel/helpers/build/configuration_snippets/truststore.xml
@@ -1,4 +1,5 @@
 <server description="Default Server">
-    <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" trustDefaultCerts="true" />
+    <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" trustDefaultCerts="${SEC_TLS_TRUSTDEFAULTCERTS}" />
     <keyStore id="defaultTrustStore" location="${server.output.dir}/resources/security/trust.p12" type="PKCS12" password="PWD_TRUST" />
+    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="false"/>
 </server>

--- a/releases/20.0.0.3/kernel/helpers/build/configure.sh
+++ b/releases/20.0.0.3/kernel/helpers/build/configure.sh
@@ -76,8 +76,8 @@ then
   then
     # Generate the keystore.xml
     export KEYSTOREPWD=$(openssl rand -base64 32)
-    sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
-    cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+    sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+    chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
 fi
 

--- a/releases/20.0.0.3/kernel/helpers/runtime/docker-server.sh
+++ b/releases/20.0.0.3/kernel/helpers/runtime/docker-server.sh
@@ -24,25 +24,27 @@ function importKeyCert() {
       -out "${KEYSTORE_FILE}" \
       -password pass:"${PASSWORD}" >&/dev/null
 
-
+    # Since we are creating new keystore, always write new password to a file
+    sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+    
     # Add mounted CA to the truststore
     if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
         echo "Found mounted TLS CA certificate, adding to truststore"
         keytool -import -storetype pkcs12 -noprompt -keystore "${TRUSTSTORE_FILE}" -file "${CERT_FOLDER}/${CA_FILE}" \
-          -storepass "${PASSWORD}" -alias "service-ca" >&/dev/null    
+          -storepass "${TRUSTSTORE_PASSWORD}" -alias "service-ca" >&/dev/null    
     fi
   fi
 
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
-  if [ "$IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
+  if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
     mkdir /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
     csplit -s -z -f crt- "${TMP_CERT}" "${CRT_DELIMITER}" '{*}'
     for CERT_FILE in crt-*; do
       keytool -import -storetype pkcs12 -noprompt -keystore "${TRUSTSTORE_FILE}" -file "${CERT_FILE}" \
-        -storepass "${PASSWORD}" -alias "service-sa-${CERT_FILE}" >&/dev/null
+        -storepass "${TRUSTSTORE_PASSWORD}" -alias "service-sa-${CERT_FILE}" >&/dev/null
     done
     popd >&/dev/null
     rm -rf /tmp/certs
@@ -50,14 +52,12 @@ function importKeyCert() {
 
   # Add the keystore password to server configuration
   if [ ! -e $keystorePath ]; then
-    sed -i.bak "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml
-    cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+    sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
   if [ -e $TRUSTSTORE_FILE ]; then
-    sed -i.bak "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml
-    cp $SNIPPETS_SOURCE/truststore.xml $SNIPPETS_TARGET_DEFAULTS/truststore.xml
+    sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
   else
-    cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_DEFAULTS/trustDefault.xml  
+    cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
   fi
 }
 


### PR DESCRIPTION
Update 20.0.0.3 with $SEC_TLS_TRUSTDEFAULTCERTS environment variable.
Fixes truststore password variable