### PR TITLE
Reduce number of iterations to populate OpenJ9 SCC

### DIFF
--- a/releases/20.0.0.3/kernel/helpers/build/populate_scc.sh
+++ b/releases/20.0.0.3/kernel/helpers/build/populate_scc.sh
@@ -6,7 +6,7 @@ fi
 set -Eeox pipefail
 
 SCC_SIZE="80m"  # Default size of the SCC layer.
-ITERATIONS=3    # Number of iterations to run to populate it.
+ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
 while getopts ":i:s:tdh" OPT

--- a/releases/latest/kernel/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel/helpers/build/populate_scc.sh
@@ -6,7 +6,7 @@ fi
 set -Eeox pipefail
 
 SCC_SIZE="80m"  # Default size of the SCC layer.
-ITERATIONS=3    # Number of iterations to run to populate it.
+ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
 while getopts ":i:s:tdh" OPT


### PR DESCRIPTION
Reduce the number of server start/stops used to populate the OpenJ9 SCC from 3 to 2.

Based on various experiments with the kernel image and some app images, the start-up time benefits of that 3rd iteration appear to be small and are probably not worth it, especially for Docker image build pipelines that are relatively resource constrained.