### PR TITLE
Use multi-layer SCCs for IBM JDK

### DIFF
--- a/releases/20.0.0.3/kernel/Dockerfile.ubi.ibmjava8
+++ b/releases/20.0.0.3/kernel/Dockerfile.ubi.ibmjava8
@@ -3,6 +3,7 @@ ARG LIBERTY_VERSION=20.0.0.3
 ARG LIBERTY_SHA=49180c2cd6ce23f863760d837a4b1663680084db
 ARG LIBERTY_BUILD_LABEL=cl200320200305-1433
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
+ARG OPENJ9_SCC=true
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \
@@ -38,7 +39,8 @@ RUN yum -y install wget unzip \
 ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
-    WLP_SKIP_MAXPERMSIZE=true
+    WLP_SKIP_MAXPERMSIZE=true \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
@@ -70,6 +72,11 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/releases/latest/kernel/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/kernel/Dockerfile.ubi.ibmjava8
@@ -3,6 +3,7 @@ ARG LIBERTY_VERSION=20.0.0.3
 ARG LIBERTY_SHA=49180c2cd6ce23f863760d837a4b1663680084db
 ARG LIBERTY_BUILD_LABEL=cl200320200305-1433
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
+ARG OPENJ9_SCC=true
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \
@@ -38,7 +39,8 @@ RUN yum -y install wget unzip \
 ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
-    WLP_SKIP_MAXPERMSIZE=true
+    WLP_SKIP_MAXPERMSIZE=true \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
@@ -70,6 +72,11 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \


### PR DESCRIPTION
This patch enables the generation of a SCC for IBM JDK, similar to how #117 enabled the same functionality for OpenJ9.