### PR TITLE
Update configure.sh to support sso source lists

### DIFF
--- a/releases/20.0.0.3/kernel/helpers/build/configure.sh
+++ b/releases/20.0.0.3/kernel/helpers/build/configure.sh
@@ -1,113 +1,139 @@
 #!/bin/bash
+
 if [ "$VERBOSE" != "true" ]; then
   exec &>/dev/null
 fi
 
 set -Eeox pipefail
 
-##Define variables for XML snippets source and target paths
-WLP_INSTALL_DIR=/opt/ol/wlp
-SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
-SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
+function main() {
+  ##Define variables for XML snippets source and target paths
+  WLP_INSTALL_DIR=/opt/ol/wlp
+  SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
+  SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
 
-SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
-SNIPPETS_TARGET=/config/configDropins/overrides
-SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
-mkdir -p ${SNIPPETS_TARGET}
-mkdir -p ${SNIPPETS_TARGET_DEFAULTS}
+  SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+  SNIPPETS_TARGET=/config/configDropins/overrides
+  SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
+  mkdir -p ${SNIPPETS_TARGET}
+  mkdir -p ${SNIPPETS_TARGET_DEFAULTS}
 
-#Check for each Liberty value-add functionality
+  #Check for each Liberty value-add functionality
 
-# MicroProfile Health
-if [ "$MP_HEALTH_CHECK" == "true" ]; then
-  cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
-fi
+  # MicroProfile Health
+  if [ "$MP_HEALTH_CHECK" == "true" ]; then
+    cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
+  fi
 
-# MicroProfile Monitoring
-if [ "$MP_MONITORING" == "true" ]; then
-  cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
-fi
+  # MicroProfile Monitoring
+  if [ "$MP_MONITORING" == "true" ]; then
+    cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
+  fi
 
-# HTTP Endpoint
-if [ "$HTTP_ENDPOINT" == "true" ]; then
+  # HTTP Endpoint
+  if [ "$HTTP_ENDPOINT" == "true" ]; then
+    if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+      cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
+    else
+      cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
+    fi
+  fi
+
+  # Hazelcast Session Caching
+  if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]; then
+    cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
+    mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
+    cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
+  fi
+
+  # IIOP Endpoint
+  if [ "$IIOP_ENDPOINT" == "true" ]; then
+    if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+      cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
+    else
+      cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
+    fi
+  fi
+
+  # JMS Endpoint
+  if [ "$JMS_ENDPOINT" == "true" ]; then
+    if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+      cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
+    else
+      cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
+    fi
+  fi
+
+  # Key Store
+  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
   if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
-    cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
-  else
-    cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
+    cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
   fi
-fi
 
-# Hazelcast Session Caching
-if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]
-then
- cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
- mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
- cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
-fi
-
-# IIOP Endpoint
-if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
-    cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
-  else
-    cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
+  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+    if [ ! -e $keystorePath ]; then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+    fi
   fi
-fi
 
-# JMS Endpoint
-if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
-    cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
-  else
-    cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
+  if [[ -n "$SEC_SSO_PROVIDERS" ]]; then
+    cp $SNIPPETS_SOURCE/sso-features.xml $SNIPPETS_TARGET_DEFAULTS
+    parseProviders $SEC_SSO_PROVIDERS
   fi
-fi
 
-# Key Store
-keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
-if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
-then
-  cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
-fi
-
-if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]
-then
-  if [ ! -e $keystorePath ]
-  then
-    # Generate the keystore.xml
-    export KEYSTOREPWD=$(openssl rand -base64 32)
-    sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
-    chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  # Create a new SCC layer
+  if [ "$OPENJ9_SCC" == "true" ]; then
+    populate_scc.sh
   fi
-fi
+}
 
-if [[ -n "$SEC_SSO_PROVIDERS" ]]; then
-  cp $SNIPPETS_SOURCE/sso-features.xml $SNIPPETS_TARGET_DEFAULTS
-  if [[ $SEC_SSO_PROVIDERS == *"oidc"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-oidc.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-  if [[ $SEC_SSO_PROVIDERS == *"oauth2"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-oauth2.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-  if [[ $SEC_SSO_PROVIDERS == *"facebook"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-facebook.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-  if [[ $SEC_SSO_PROVIDERS == *"twitter"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-twitter.xml $SNIPPETS_TARGET_DEFAULTS
-    fi    
-  if [[ $SEC_SSO_PROVIDERS == *"linkedin"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-linkedin.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-  if [[ $SEC_SSO_PROVIDERS == *"google"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-google.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-  if [[ $SEC_SSO_PROVIDERS == *"github"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-github.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-fi
+## parse provider list to generate files into configDropins
+function parseProviders() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    oidc:*)
+      parseSourceList oidc "${1#*:}"
+      ;;
+    oauth2:*)
+      parseSourceList oauth2 "${1#*:}"
+      ;;
+    *)
+      if [[ $(ls $SNIPPETS_SOURCE | grep "$1") ]]; then
+        cp $SNIPPETS_SOURCE/sso-${1}.xml $SNIPPETS_TARGET_DEFAULTS
+      fi
+      ;;
+    esac
+    shift
+  done
+}
 
-# Create a new SCC layer
-if [ "$OPENJ9_SCC" == "true" ]
-then
-  populate_scc.sh
-fi
+## process the comma delimitted oauth2/oidc source lists
+function parseSourceList() {
+  local type="$1"
+  local list=$(echo "$2" | tr , " ")
+
+  for current in ${list}; do
+    if [[ "${type}" = "oidc" ]]; then
+      cp $SNIPPETS_SOURCE/sso-oidc.xml $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      # replace id and login id
+      sed -i.bak -e 's/=\"oidc/=\"'${current}'/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      sed -i.bak -e 's/_OIDC_/_'$(toUpper ${current})'_/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      rm $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml.bak
+    else
+      cp $SNIPPETS_SOURCE/sso-oauth2.xml $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      # replace id and login id
+      sed -i.bak -e 's/=\"oauth2/=\"'${current}'/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      sed -i.bak -e 's/_OAUTH2_/_'$(toUpper ${current})'_/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      rm $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml.bak
+    fi
+  done
+}
+
+function toUpper() {
+  echo $(printf '%s\n' "$1" | awk '{ print toupper($0) }')
+}
+
+main $@

--- a/releases/20.0.0.3/kernel/helpers/build/configure.sh
+++ b/releases/20.0.0.3/kernel/helpers/build/configure.sh
@@ -1,139 +1,113 @@
 #!/bin/bash
-
 if [ "$VERBOSE" != "true" ]; then
   exec &>/dev/null
 fi
 
 set -Eeox pipefail
 
-function main() {
-  ##Define variables for XML snippets source and target paths
-  WLP_INSTALL_DIR=/opt/ol/wlp
-  SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
-  SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
+##Define variables for XML snippets source and target paths
+WLP_INSTALL_DIR=/opt/ol/wlp
+SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
+SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
 
-  SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
-  SNIPPETS_TARGET=/config/configDropins/overrides
-  SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
-  mkdir -p ${SNIPPETS_TARGET}
-  mkdir -p ${SNIPPETS_TARGET_DEFAULTS}
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
+mkdir -p ${SNIPPETS_TARGET}
+mkdir -p ${SNIPPETS_TARGET_DEFAULTS}
 
-  #Check for each Liberty value-add functionality
+#Check for each Liberty value-add functionality
 
-  # MicroProfile Health
-  if [ "$MP_HEALTH_CHECK" == "true" ]; then
-    cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
-  fi
+# MicroProfile Health
+if [ "$MP_HEALTH_CHECK" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
+fi
 
-  # MicroProfile Monitoring
-  if [ "$MP_MONITORING" == "true" ]; then
-    cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
-  fi
+# MicroProfile Monitoring
+if [ "$MP_MONITORING" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
+fi
 
-  # HTTP Endpoint
-  if [ "$HTTP_ENDPOINT" == "true" ]; then
-    if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
-      cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
-    else
-      cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
-    fi
-  fi
-
-  # Hazelcast Session Caching
-  if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]; then
-    cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
-    mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
-    cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
-  fi
-
-  # IIOP Endpoint
-  if [ "$IIOP_ENDPOINT" == "true" ]; then
-    if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
-      cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
-    else
-      cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
-    fi
-  fi
-
-  # JMS Endpoint
-  if [ "$JMS_ENDPOINT" == "true" ]; then
-    if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
-      cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
-    else
-      cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
-    fi
-  fi
-
-  # Key Store
-  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+# HTTP Endpoint
+if [ "$HTTP_ENDPOINT" == "true" ]; then
   if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
-    cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
+    cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
   fi
+fi
 
-  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
-    if [ ! -e $keystorePath ]; then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
-      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+# Hazelcast Session Caching
+if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]
+then
+ cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
+ mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
+ cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
+fi
+
+# IIOP Endpoint
+if [ "$IIOP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+    cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
+  fi
+fi
+
+# JMS Endpoint
+if [ "$JMS_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+    cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
+  fi
+fi
+
+# Key Store
+keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+  cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
+fi
+
+if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]
+then
+  if [ ! -e $keystorePath ]
+  then
+    # Generate the keystore.xml
+    export KEYSTOREPWD=$(openssl rand -base64 32)
+    sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+    chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  fi
+fi
+
+if [[ -n "$SEC_SSO_PROVIDERS" ]]; then
+  cp $SNIPPETS_SOURCE/sso-features.xml $SNIPPETS_TARGET_DEFAULTS
+  if [[ $SEC_SSO_PROVIDERS == *"oidc"* ]]; then
+    cp $SNIPPETS_SOURCE/sso-oidc.xml $SNIPPETS_TARGET_DEFAULTS
     fi
-  fi
-
-  if [[ -n "$SEC_SSO_PROVIDERS" ]]; then
-    cp $SNIPPETS_SOURCE/sso-features.xml $SNIPPETS_TARGET_DEFAULTS
-    parseProviders $SEC_SSO_PROVIDERS
-  fi
-
-  # Create a new SCC layer
-  if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh
-  fi
-}
-
-## parse provider list to generate files into configDropins
-function parseProviders() {
-  while [ $# -gt 0 ]; do
-    case "$1" in
-    oidc:*)
-      parseSourceList oidc "${1#*:}"
-      ;;
-    oauth2:*)
-      parseSourceList oauth2 "${1#*:}"
-      ;;
-    *)
-      if [[ $(ls $SNIPPETS_SOURCE | grep "$1") ]]; then
-        cp $SNIPPETS_SOURCE/sso-${1}.xml $SNIPPETS_TARGET_DEFAULTS
-      fi
-      ;;
-    esac
-    shift
-  done
-}
-
-## process the comma delimitted oauth2/oidc source lists
-function parseSourceList() {
-  local type="$1"
-  local list=$(echo "$2" | tr , " ")
-
-  for current in ${list}; do
-    if [[ "${type}" = "oidc" ]]; then
-      cp $SNIPPETS_SOURCE/sso-oidc.xml $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      # replace id and login id
-      sed -i.bak -e 's/=\"oidc/=\"'${current}'/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      sed -i.bak -e 's/_OIDC_/_'$(toUpper ${current})'_/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      rm $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml.bak
-    else
-      cp $SNIPPETS_SOURCE/sso-oauth2.xml $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      # replace id and login id
-      sed -i.bak -e 's/=\"oauth2/=\"'${current}'/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      sed -i.bak -e 's/_OAUTH2_/_'$(toUpper ${current})'_/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      rm $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml.bak
+  if [[ $SEC_SSO_PROVIDERS == *"oauth2"* ]]; then
+    cp $SNIPPETS_SOURCE/sso-oauth2.xml $SNIPPETS_TARGET_DEFAULTS
     fi
-  done
-}
+  if [[ $SEC_SSO_PROVIDERS == *"facebook"* ]]; then
+    cp $SNIPPETS_SOURCE/sso-facebook.xml $SNIPPETS_TARGET_DEFAULTS
+    fi
+  if [[ $SEC_SSO_PROVIDERS == *"twitter"* ]]; then
+    cp $SNIPPETS_SOURCE/sso-twitter.xml $SNIPPETS_TARGET_DEFAULTS
+    fi    
+  if [[ $SEC_SSO_PROVIDERS == *"linkedin"* ]]; then
+    cp $SNIPPETS_SOURCE/sso-linkedin.xml $SNIPPETS_TARGET_DEFAULTS
+    fi
+  if [[ $SEC_SSO_PROVIDERS == *"google"* ]]; then
+    cp $SNIPPETS_SOURCE/sso-google.xml $SNIPPETS_TARGET_DEFAULTS
+    fi
+  if [[ $SEC_SSO_PROVIDERS == *"github"* ]]; then
+    cp $SNIPPETS_SOURCE/sso-github.xml $SNIPPETS_TARGET_DEFAULTS
+    fi
+fi
 
-function toUpper() {
-  echo $(printf '%s\n' "$1" | awk '{ print toupper($0) }')
-}
-
-main $@
+# Create a new SCC layer
+if [ "$OPENJ9_SCC" == "true" ]
+then
+  populate_scc.sh
+fi

--- a/releases/latest/kernel/helpers/build/configure.sh
+++ b/releases/latest/kernel/helpers/build/configure.sh
@@ -1,113 +1,139 @@
 #!/bin/bash
+
 if [ "$VERBOSE" != "true" ]; then
   exec &>/dev/null
 fi
 
 set -Eeox pipefail
 
-##Define variables for XML snippets source and target paths
-WLP_INSTALL_DIR=/opt/ol/wlp
-SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
-SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
+function main() {
+  ##Define variables for XML snippets source and target paths
+  WLP_INSTALL_DIR=/opt/ol/wlp
+  SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
+  SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
 
-SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
-SNIPPETS_TARGET=/config/configDropins/overrides
-SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
-mkdir -p ${SNIPPETS_TARGET}
-mkdir -p ${SNIPPETS_TARGET_DEFAULTS}
+  SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+  SNIPPETS_TARGET=/config/configDropins/overrides
+  SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
+  mkdir -p ${SNIPPETS_TARGET}
+  mkdir -p ${SNIPPETS_TARGET_DEFAULTS}
 
-#Check for each Liberty value-add functionality
+  #Check for each Liberty value-add functionality
 
-# MicroProfile Health
-if [ "$MP_HEALTH_CHECK" == "true" ]; then
-  cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
-fi
+  # MicroProfile Health
+  if [ "$MP_HEALTH_CHECK" == "true" ]; then
+    cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
+  fi
 
-# MicroProfile Monitoring
-if [ "$MP_MONITORING" == "true" ]; then
-  cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
-fi
+  # MicroProfile Monitoring
+  if [ "$MP_MONITORING" == "true" ]; then
+    cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
+  fi
 
-# HTTP Endpoint
-if [ "$HTTP_ENDPOINT" == "true" ]; then
+  # HTTP Endpoint
+  if [ "$HTTP_ENDPOINT" == "true" ]; then
+    if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+      cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
+    else
+      cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
+    fi
+  fi
+
+  # Hazelcast Session Caching
+  if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]; then
+    cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
+    mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
+    cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
+  fi
+
+  # IIOP Endpoint
+  if [ "$IIOP_ENDPOINT" == "true" ]; then
+    if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+      cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
+    else
+      cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
+    fi
+  fi
+
+  # JMS Endpoint
+  if [ "$JMS_ENDPOINT" == "true" ]; then
+    if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
+      cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
+    else
+      cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
+    fi
+  fi
+
+  # Key Store
+  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
   if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
-    cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
-  else
-    cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
+    cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
   fi
-fi
 
-# Hazelcast Session Caching
-if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]
-then
- cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
- mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
- cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
-fi
-
-# IIOP Endpoint
-if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
-    cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
-  else
-    cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
+  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+    if [ ! -e $keystorePath ]; then
+      # Generate the keystore.xml
+      export KEYSTOREPWD=$(openssl rand -base64 32)
+      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+    fi
   fi
-fi
 
-# JMS Endpoint
-if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
-    cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
-  else
-    cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
+  if [[ -n "$SEC_SSO_PROVIDERS" ]]; then
+    cp $SNIPPETS_SOURCE/sso-features.xml $SNIPPETS_TARGET_DEFAULTS
+    parseProviders $SEC_SSO_PROVIDERS
   fi
-fi
 
-# Key Store
-keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
-if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
-then
-  cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
-fi
-
-if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]
-then
-  if [ ! -e $keystorePath ]
-  then
-    # Generate the keystore.xml
-    export KEYSTOREPWD=$(openssl rand -base64 32)
-    sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
-    chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  # Create a new SCC layer
+  if [ "$OPENJ9_SCC" == "true" ]; then
+    populate_scc.sh
   fi
-fi
+}
 
-if [[ -n "$SEC_SSO_PROVIDERS" ]]; then
-  cp $SNIPPETS_SOURCE/sso-features.xml $SNIPPETS_TARGET_DEFAULTS
-  if [[ $SEC_SSO_PROVIDERS == *"oidc"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-oidc.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-  if [[ $SEC_SSO_PROVIDERS == *"oauth2"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-oauth2.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-  if [[ $SEC_SSO_PROVIDERS == *"facebook"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-facebook.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-  if [[ $SEC_SSO_PROVIDERS == *"twitter"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-twitter.xml $SNIPPETS_TARGET_DEFAULTS
-    fi    
-  if [[ $SEC_SSO_PROVIDERS == *"linkedin"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-linkedin.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-  if [[ $SEC_SSO_PROVIDERS == *"google"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-google.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-  if [[ $SEC_SSO_PROVIDERS == *"github"* ]]; then
-    cp $SNIPPETS_SOURCE/sso-github.xml $SNIPPETS_TARGET_DEFAULTS
-    fi
-fi
+## parse provider list to generate files into configDropins
+function parseProviders() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    oidc:*)
+      parseCommaList oidc "${1#*:}"
+      ;;
+    oauth2:*)
+      parseCommaList oauth2 "${1#*:}"
+      ;;
+    *)
+      if [[ $(ls $SNIPPETS_SOURCE | grep "$1") ]]; then
+        cp $SNIPPETS_SOURCE/sso-${1}.xml $SNIPPETS_TARGET_DEFAULTS
+      fi
+      ;;
+    esac
+    shift
+  done
+}
 
-# Create a new SCC layer
-if [ "$OPENJ9_SCC" == "true" ]
-then
-  populate_scc.sh
-fi
+## process the comma delimitted oauth2/oidc source lists
+function parseCommaList() {
+  local type="$1"
+  local list=$(echo "$2" | tr , " ")
+
+  for current in ${list}; do
+    if [[ "${type}" = "oidc" ]]; then
+      cp $SNIPPETS_SOURCE/sso-oidc.xml $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      # replace oidc identifiers with custom name
+      sed -i.bak -e 's/=\"oidc/=\"'${current}'/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      sed -i.bak -e 's/_OIDC_/_'$(toUpper ${current})'_/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      rm $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml.bak
+    else
+      cp $SNIPPETS_SOURCE/sso-oauth2.xml $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      # replace oidc identifiers with custom name
+      sed -i.bak -e 's/=\"oauth2/=\"'${current}'/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      sed -i.bak -e 's/_OAUTH2_/_'$(toUpper ${current})'_/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
+      rm $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml.bak
+    fi
+  done
+}
+
+function toUpper() {
+  echo $(printf '%s\n' "$1" | awk '{ print toupper($0) }')
+}
+
+main $@

--- a/releases/latest/kernel/helpers/build/configure.sh
+++ b/releases/latest/kernel/helpers/build/configure.sh
@@ -117,17 +117,11 @@ function parseCommaList() {
 
   for current in ${list}; do
     if [[ "${type}" = "oidc" ]]; then
-      cp $SNIPPETS_SOURCE/sso-oidc.xml $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
       # replace oidc identifiers with custom name
-      sed -i.bak -e 's/=\"oidc/=\"'${current}'/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      sed -i.bak -e 's/_OIDC_/_'$(toUpper ${current})'_/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      rm $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml.bak
+      sed -e 's/=\"oidc/=\"'${current}'/g' -e 's/_OIDC_/_'$(toUpper ${current})'_/g' $SNIPPETS_SOURCE/sso-oidc.xml > $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
     else
-      cp $SNIPPETS_SOURCE/sso-oauth2.xml $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      # replace oidc identifiers with custom name
-      sed -i.bak -e 's/=\"oauth2/=\"'${current}'/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      sed -i.bak -e 's/_OAUTH2_/_'$(toUpper ${current})'_/g' $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
-      rm $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml.bak
+      # replace oauth2 identifiers with custom name
+      sed -e 's/=\"oauth2/=\"'${current}'/g' -e 's/_OAUTH2_/_'$(toUpper ${current})'_/g' $SNIPPETS_SOURCE/sso-oauth2.xml > $SNIPPETS_TARGET_DEFAULTS/sso-${current}.xml
     fi
   done
 }


### PR DESCRIPTION
- Adds support for extending oauth2 or oidc as follows: `oauth2:custom,custom2`.
- Allows for `oauth2:custom,custom2 oauth2` to also include the original default snippet file.
- When defined it will loop through comma delimited list and do the following:
  - Replaces `defaultValue=oidcLogin`, `*_OIDC_*`, or `id=oidc` with custom source name. And likewise for `oauth2`. 
  - Names the resulting file `sso-{custom-name}.xml`, copying into snippet defaults.

Separated the uglier parts of the script into helper functions at the bottom. Didn't want to create another script file to package into the docker image, but I can do that if we want to keep configure.sh as simple as possible.