### PR TITLE
Add OpenJ9 SCC layer to full images

### DIFF
--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
@@ -1,3 +1,9 @@
 FROM openliberty/open-liberty:kernel-java11-openj9-ubi
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk13
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk13
@@ -1,3 +1,9 @@
 FROM openliberty/open-liberty:kernel-java13-openj9-ubi
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
@@ -1,3 +1,9 @@
 FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/full/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/full/Dockerfile.ubi.ibmjava8
@@ -1,3 +1,9 @@
 FROM openliberty/open-liberty:kernel-java8-ibmjava-ubi
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
@@ -1,3 +1,9 @@
 FROM open-liberty:kernel-java8-openj9
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output


### PR DESCRIPTION
This should address the notable difference in start-up time between the kernel images and full images observed in https://github.com/OpenLiberty/ci.docker/issues/174.