### PR TITLE
Add trustDefault.xml only when $SEC_TLS_TRUSTDEFAULTCERTS is set

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 ### Automatically trust known certificate authorities (`20.0.0.3+`)
 
 To enable trust certificates from known certificate authorities `SEC_TLS_TRUSTDEFAULTCERTS` environment variable can be set.
-Default value is `false`. If set to true, then the default certificates from the JVM are used in addition to the configured truststore file to establish trust.
+If set to true, then the default certificates from the JVM are used in addition to the configured truststore file to establish trust.
 
 ### Providing custom certificates (`20.0.0.3+`)
 

--- a/releases/20.0.0.3/kernel/helpers/build/configuration_snippets/trustDefault.xml
+++ b/releases/20.0.0.3/kernel/helpers/build/configuration_snippets/trustDefault.xml
@@ -1,4 +1,4 @@
 <server description="Default Server">
     <ssl id="defaultSSLConfig" trustDefaultCerts="${SEC_TLS_TRUSTDEFAULTCERTS}" />
-    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="false"/>
+    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="true"/>
 </server>

--- a/releases/20.0.0.3/kernel/helpers/build/configuration_snippets/truststore.xml
+++ b/releases/20.0.0.3/kernel/helpers/build/configuration_snippets/truststore.xml
@@ -1,5 +1,5 @@
 <server description="Default Server">
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" trustDefaultCerts="${SEC_TLS_TRUSTDEFAULTCERTS}" />
     <keyStore id="defaultTrustStore" location="${server.output.dir}/resources/security/trust.p12" type="PKCS12" password="PWD_TRUST" />
-    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="false"/>
+    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="true"/>
 </server>

--- a/releases/20.0.0.3/kernel/helpers/runtime/docker-server.sh
+++ b/releases/20.0.0.3/kernel/helpers/runtime/docker-server.sh
@@ -56,7 +56,7 @@ function importKeyCert() {
   fi
   if [ -e $TRUSTSTORE_FILE ]; then
     sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
-  else
+  elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
     cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
   fi
 }

--- a/releases/20.0.0.4/kernel/helpers/build/configuration_snippets/trustDefault.xml
+++ b/releases/20.0.0.4/kernel/helpers/build/configuration_snippets/trustDefault.xml
@@ -1,4 +1,4 @@
 <server description="Default Server">
     <ssl id="defaultSSLConfig" trustDefaultCerts="${SEC_TLS_TRUSTDEFAULTCERTS}" />
-    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="false"/>
+    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="true"/>
 </server>

--- a/releases/20.0.0.4/kernel/helpers/build/configuration_snippets/truststore.xml
+++ b/releases/20.0.0.4/kernel/helpers/build/configuration_snippets/truststore.xml
@@ -1,5 +1,5 @@
 <server description="Default Server">
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" trustDefaultCerts="${SEC_TLS_TRUSTDEFAULTCERTS}" />
     <keyStore id="defaultTrustStore" location="${server.output.dir}/resources/security/trust.p12" type="PKCS12" password="PWD_TRUST" />
-    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="false"/>
+    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="true"/>
 </server>

--- a/releases/20.0.0.4/kernel/helpers/runtime/docker-server.sh
+++ b/releases/20.0.0.4/kernel/helpers/runtime/docker-server.sh
@@ -56,7 +56,7 @@ function importKeyCert() {
   fi
   if [ -e $TRUSTSTORE_FILE ]; then
     sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
-  else
+  elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
     cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
   fi
 }

--- a/releases/latest/kernel/helpers/build/configuration_snippets/trustDefault.xml
+++ b/releases/latest/kernel/helpers/build/configuration_snippets/trustDefault.xml
@@ -1,4 +1,4 @@
 <server description="Default Server">
     <ssl id="defaultSSLConfig" trustDefaultCerts="${SEC_TLS_TRUSTDEFAULTCERTS}" />
-    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="false"/>
+    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="true"/>
 </server>

--- a/releases/latest/kernel/helpers/build/configuration_snippets/truststore.xml
+++ b/releases/latest/kernel/helpers/build/configuration_snippets/truststore.xml
@@ -1,5 +1,5 @@
 <server description="Default Server">
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" trustDefaultCerts="${SEC_TLS_TRUSTDEFAULTCERTS}" />
     <keyStore id="defaultTrustStore" location="${server.output.dir}/resources/security/trust.p12" type="PKCS12" password="PWD_TRUST" />
-    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="false"/>
+    <variable name="SEC_TLS_TRUSTDEFAULTCERTS" defaultValue="true"/>
 </server>

--- a/releases/latest/kernel/helpers/runtime/docker-server.sh
+++ b/releases/latest/kernel/helpers/runtime/docker-server.sh
@@ -56,7 +56,7 @@ function importKeyCert() {
   fi
   if [ -e $TRUSTSTORE_FILE ]; then
     sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
-  else
+  elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
     cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
   fi
 }


### PR DESCRIPTION
Fixes issue #158 as well gets rid of warning of a conflict with server.xml