### PR TITLE
Fix potential max heap issues with OpenJ9 SCCs

### DIFF
--- a/releases/latest/kernel/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel/helpers/build/populate_scc.sh
@@ -9,6 +9,11 @@ SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
+export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+CREATE_LAYER="$IBM_JAVA_OPTIONS,createLayer,groupAccess"
+DESTROY_LAYER="$IBM_JAVA_OPTIONS,destroy"
+PRINT_LAYER_STATS="$IBM_JAVA_OPTIONS,printTopLayerStats"
+
 while getopts ":i:s:tdh" OPT
 do
   case "$OPT" in
@@ -47,29 +52,23 @@ do
   esac
 done
 
-# Make sure the following Java commands don't disturb our class cache until we're ready to populate it
-# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
-unset IBM_JAVA_OPTIONS
-
 OLD_UMASK=`umask`
 umask 002 # 002 is required to provide group rw permission to the cache when `-Xshareclasses:groupAccess` options is used
 
 # Explicity create a class cache layer for this image layer here rather than allowing
 # `server start` to do it, which will lead to problems because multiple JVMs will be started.
-java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer,groupAccess -Xscmx$SCC_SIZE -version
+java $CREATE_LAYER -Xscmx$SCC_SIZE -version
 
 if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
   /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
   # Find out how full it is.
-  unset IBM_JAVA_OPTIONS
-  FULL=`( java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,printTopLayerStats || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
+  FULL=`( java $PRINT_LAYER_STATS || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
   echo "SCC layer is $FULL% full. Destroying layer."
   # Destroy the layer once we know roughly how much space we need.
-  java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true
+  java $DESTROY_LAYER || true
   # Remove the m suffix.
   SCC_SIZE="${SCC_SIZE:0:-1}"
   # Calculate the new size based on how full the layer was (rounded to nearest m).
@@ -80,12 +79,10 @@ then
   SCC_SIZE="${SCC_SIZE}m"
   echo "Re-creating layer with size $SCC_SIZE."
   # Recreate the layer with the new size.
-  java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer,groupAccess -Xscmx$SCC_SIZE -version
+  java $CREATE_LAYER -Xscmx$SCC_SIZE -version
 fi
 
 # Populate the newly created class cache layer.
-export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
-
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
@@ -102,7 +99,7 @@ then
     chmod -R g+rwx /output/resources
 fi
 
-unset IBM_JAVA_OPTIONS
+
 # Tell the user how full the final layer is.
-FULL=`( java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,printTopLayerStats || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
+FULL=`( java $PRINT_LAYER_STATS || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
 echo "SCC layer is $FULL% full."

--- a/releases/latest/kernel/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel/helpers/build/populate_scc.sh
@@ -9,7 +9,15 @@ SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
-export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+# For JDK8, as of OpenJ9 0.20.0 the criteria for determining the max heap size (-Xmx) has changed
+# and the JVM has freedom to choose larger max heap sizes.
+# Currently in compressedrefs mode there is a dependency between heap size and position and the AOT code stored in the
+# SCC, such that if the max heap size/position changes too drastically the AOT code in the SCC becomes invalid and will
+# not be loaded. Also, new AOT code will not be generated.
+# In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
+# option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
+# The option has no effect on later JDKs.
+export IBM_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
 CREATE_LAYER="$IBM_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$IBM_JAVA_OPTIONS,destroy"
 PRINT_LAYER_STATS="$IBM_JAVA_OPTIONS,printTopLayerStats"


### PR DESCRIPTION
Previous versions of OpenJ9 JDK8 ran with a default max heap (`-Xmx`) of 512m. New versions run with a dynamic setting based on the host's available memory (OpenJ9 JDK11 and later have always used the dynamic setting).

This change exposes an issue when we include SCCs in images, namely that the AOT code in SCCs is sensitive the heap geometry and can't tolerate certain changes to the max heap setting. If the current max heap setting is not compatible with the AOT code in the SCC the code won't be used and new code won't be added to the SCC, which can lead to noticeable startup performance fluctuations and degradations.

This set of patches makes changes to 1) populate SCCs with `-Xmx512m`, 2) adds `-Xmx512m` to `IBM_JAVA_OPTIONS` such that by default servers will run with a compatible max heap setting.