### PR TITLE
Prefer Liberty SCC to OpenJ9 SCC

### DIFF
--- a/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -83,7 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk14
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk14
@@ -83,7 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -83,7 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/20.0.0.6/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -81,7 +81,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/20.0.0.6/kernel/helpers/build/populate_scc.sh
+++ b/releases/20.0.0.6/kernel/helpers/build/populate_scc.sh
@@ -17,10 +17,10 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export IBM_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
-CREATE_LAYER="$IBM_JAVA_OPTIONS,createLayer,groupAccess"
-DESTROY_LAYER="$IBM_JAVA_OPTIONS,destroy"
-PRINT_LAYER_STATS="$IBM_JAVA_OPTIONS,printTopLayerStats"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
+DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
+PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"
 
 while getopts ":i:s:tdh" OPT
 do

--- a/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -83,7 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk14
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk14
@@ -83,7 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -83,7 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/20.0.0.9/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -81,7 +81,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/20.0.0.9/kernel/helpers/build/populate_scc.sh
+++ b/releases/20.0.0.9/kernel/helpers/build/populate_scc.sh
@@ -17,10 +17,10 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export IBM_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
-CREATE_LAYER="$IBM_JAVA_OPTIONS,createLayer,groupAccess"
-DESTROY_LAYER="$IBM_JAVA_OPTIONS,destroy"
-PRINT_LAYER_STATS="$IBM_JAVA_OPTIONS,printTopLayerStats"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
+DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
+PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"
 
 while getopts ":i:s:tdh" OPT
 do

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -83,7 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk14
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk14
@@ -83,7 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -83,7 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -81,7 +81,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/releases/latest/kernel/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel/helpers/build/populate_scc.sh
@@ -17,10 +17,10 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export IBM_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
-CREATE_LAYER="$IBM_JAVA_OPTIONS,createLayer,groupAccess"
-DESTROY_LAYER="$IBM_JAVA_OPTIONS,destroy"
-PRINT_LAYER_STATS="$IBM_JAVA_OPTIONS,printTopLayerStats"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
+DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
+PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"
 
 while getopts ":i:s:tdh" OPT
 do


### PR DESCRIPTION
OpenJ9 images now ship with an SCC that we can use as a base SCC layer.

Fixes #203

FYI @jdmcclur, can you give this patch a try?