### PR TITLE
Use OpenJ9 system SCC where possible

### DIFF
--- a/releases/20.0.0.11/full/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.11/full/Dockerfile.ubi.adoptopenjdk11
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.11/full/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.11/full/Dockerfile.ubi.adoptopenjdk11
@@ -82,8 +82,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.11/full/Dockerfile.ubi.adoptopenjdk14
+++ b/releases/20.0.0.11/full/Dockerfile.ubi.adoptopenjdk14
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.11/full/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.11/full/Dockerfile.ubi.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.11/full/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.11/full/Dockerfile.ubi.adoptopenjdk8
@@ -82,8 +82,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.11/full/Dockerfile.ubi.ibmjava8
+++ b/releases/20.0.0.11/full/Dockerfile.ubi.ibmjava8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.11/full/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.11/full/Dockerfile.ubuntu.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.11/full/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.11/full/Dockerfile.ubuntu.adoptopenjdk8
@@ -80,8 +80,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.11/full/helpers/build/populate_scc.sh
+++ b/releases/20.0.0.11/full/helpers/build/populate_scc.sh
@@ -9,6 +9,15 @@ SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
+# If this directory exists and has at least ug=rwx permissions, assume the base image includes an SCC called 'openj9_system_scc' and build on it.
+# If not, build on our own SCC.
+if [[ -d "/opt/java/.scc" ]] && [[ `stat -L -c "%a" "/opt/java/.scc" | cut -c 1,2` == "77" ]]
+then
+  SCC="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc"
+else
+  SCC="-Xshareclasses:name=liberty,cacheDir=/output/.classCache"
+fi
+
 # For JDK8, as of OpenJ9 0.20.0 the criteria for determining the max heap size (-Xmx) has changed
 # and the JVM has freedom to choose larger max heap sizes.
 # Currently in compressedrefs mode there is a dependency between heap size and position and the AOT code stored in the
@@ -17,7 +26,8 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode $SCC"
+export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
 PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"

--- a/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.adoptopenjdk11
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.adoptopenjdk11
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.adoptopenjdk14
+++ b/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.adoptopenjdk14
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.adoptopenjdk8
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/20.0.0.11/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.11/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.11/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
@@ -81,8 +81,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.11/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.11/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.11/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/20.0.0.11/kernel-slim/helpers/build/populate_scc.sh
@@ -9,6 +9,15 @@ SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
+# If this directory exists and has at least ug=rwx permissions, assume the base image includes an SCC called 'openj9_system_scc' and build on it.
+# If not, build on our own SCC.
+if [[ -d "/opt/java/.scc" ]] && [[ `stat -L -c "%a" "/opt/java/.scc" | cut -c 1,2` == "77" ]]
+then
+  SCC="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc"
+else
+  SCC="-Xshareclasses:name=liberty,cacheDir=/output/.classCache"
+fi
+
 # For JDK8, as of OpenJ9 0.20.0 the criteria for determining the max heap size (-Xmx) has changed
 # and the JVM has freedom to choose larger max heap sizes.
 # Currently in compressedrefs mode there is a dependency between heap size and position and the AOT code stored in the
@@ -17,7 +26,8 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode $SCC"
+export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
 PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"

--- a/releases/20.0.0.6/full/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.6/full/Dockerfile.ubi.adoptopenjdk11
@@ -1,4 +1,5 @@
 FROM openliberty/open-liberty:20.0.0.6-kernel-java11-openj9-ubi
+ARG VERBOSE=false
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
 

--- a/releases/20.0.0.6/full/Dockerfile.ubi.adoptopenjdk14
+++ b/releases/20.0.0.6/full/Dockerfile.ubi.adoptopenjdk14
@@ -1,4 +1,5 @@
 FROM openliberty/open-liberty:20.0.0.6-kernel-java14-openj9-ubi
+ARG VERBOSE=false
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
 

--- a/releases/20.0.0.6/full/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.6/full/Dockerfile.ubi.adoptopenjdk8
@@ -1,4 +1,5 @@
 FROM openliberty/open-liberty:20.0.0.6-kernel-java8-openj9-ubi
+ARG VERBOSE=false
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
 

--- a/releases/20.0.0.6/full/Dockerfile.ubi.ibmjava8
+++ b/releases/20.0.0.6/full/Dockerfile.ubi.ibmjava8
@@ -1,4 +1,5 @@
 FROM openliberty/open-liberty:20.0.0.6-kernel-java8-ibmjava-ubi
+ARG VERBOSE=false
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
 

--- a/releases/20.0.0.6/full/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.6/full/Dockerfile.ubuntu.adoptopenjdk8
@@ -1,4 +1,5 @@
 FROM open-liberty:20.0.0.6-kernel-java8-openj9
+ARG VERBOSE=false
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
 

--- a/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=083e89c2f96972df339a513582b338658e6562b3
 ARG LIBERTY_BUILD_LABEL=cl200620200528-0414
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk14
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk14
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=083e89c2f96972df339a513582b338658e6562b3
 ARG LIBERTY_BUILD_LABEL=cl200620200528-0414
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=083e89c2f96972df339a513582b338658e6562b3
 ARG LIBERTY_BUILD_LABEL=cl200620200528-0414
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.6/kernel/Dockerfile.ubi.ibmjava8
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubi.ibmjava8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=083e89c2f96972df339a513582b338658e6562b3
 ARG LIBERTY_BUILD_LABEL=cl200620200528-0414
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.6/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -81,8 +81,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.6/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.6/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=083e89c2f96972df339a513582b338658e6562b3
 ARG LIBERTY_BUILD_LABEL=cl200620200528-0414
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.6/kernel/helpers/build/populate_scc.sh
+++ b/releases/20.0.0.6/kernel/helpers/build/populate_scc.sh
@@ -9,6 +9,15 @@ SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
+# If this directory exists and has at least ug=rwx permissions, assume the base image includes an SCC called 'openj9_system_scc' and build on it.
+# If not, build on our own SCC.
+if [[ -d "/opt/java/.scc" ]] && [[ `stat -L -c "%a" "/opt/java/.scc" | cut -c 1,2` == "77" ]]
+then
+  SCC="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc"
+else
+  SCC="-Xshareclasses:name=liberty,cacheDir=/output/.classCache"
+fi
+
 # For JDK8, as of OpenJ9 0.20.0 the criteria for determining the max heap size (-Xmx) has changed
 # and the JVM has freedom to choose larger max heap sizes.
 # Currently in compressedrefs mode there is a dependency between heap size and position and the AOT code stored in the
@@ -17,7 +26,8 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode $SCC"
+export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
 PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"

--- a/releases/20.0.0.9/full/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.9/full/Dockerfile.ubi.adoptopenjdk11
@@ -1,4 +1,5 @@
 FROM openliberty/open-liberty:20.0.0.9-kernel-java11-openj9-ubi
+ARG VERBOSE=false
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
 

--- a/releases/20.0.0.9/full/Dockerfile.ubi.adoptopenjdk14
+++ b/releases/20.0.0.9/full/Dockerfile.ubi.adoptopenjdk14
@@ -1,4 +1,5 @@
 FROM openliberty/open-liberty:20.0.0.9-kernel-java14-openj9-ubi
+ARG VERBOSE=false
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
 

--- a/releases/20.0.0.9/full/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.9/full/Dockerfile.ubi.adoptopenjdk8
@@ -1,4 +1,5 @@
 FROM openliberty/open-liberty:20.0.0.9-kernel-java8-openj9-ubi
+ARG VERBOSE=false
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
 

--- a/releases/20.0.0.9/full/Dockerfile.ubi.ibmjava8
+++ b/releases/20.0.0.9/full/Dockerfile.ubi.ibmjava8
@@ -1,4 +1,5 @@
 FROM openliberty/open-liberty:20.0.0.9-kernel-java8-ibmjava-ubi
+ARG VERBOSE=false
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
 

--- a/releases/20.0.0.9/full/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.9/full/Dockerfile.ubuntu.adoptopenjdk8
@@ -1,4 +1,5 @@
 FROM open-liberty:20.0.0.9-kernel-java8-openj9
+ARG VERBOSE=false
 
 RUN cp /opt/ol/wlp/templates/servers/javaee8/server.xml /config/server.xml
 

--- a/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=c354fd0e0d3704cc63d4f0810e38f5d081916ef4
 ARG LIBERTY_BUILD_LABEL=cl200920200820-0913
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk14
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk14
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=c354fd0e0d3704cc63d4f0810e38f5d081916ef4
 ARG LIBERTY_BUILD_LABEL=cl200920200820-0913
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=c354fd0e0d3704cc63d4f0810e38f5d081916ef4
 ARG LIBERTY_BUILD_LABEL=cl200920200820-0913
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.9/kernel/Dockerfile.ubi.ibmjava8
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubi.ibmjava8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=c354fd0e0d3704cc63d4f0810e38f5d081916ef4
 ARG LIBERTY_BUILD_LABEL=cl200920200820-0913
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.9/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -81,8 +81,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/20.0.0.9/kernel/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/20.0.0.9/kernel/Dockerfile.ubuntu.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=c354fd0e0d3704cc63d4f0810e38f5d081916ef4
 ARG LIBERTY_BUILD_LABEL=cl200920200820-0913
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/20.0.0.9/kernel/helpers/build/populate_scc.sh
+++ b/releases/20.0.0.9/kernel/helpers/build/populate_scc.sh
@@ -9,6 +9,15 @@ SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
+# If this directory exists and has at least ug=rwx permissions, assume the base image includes an SCC called 'openj9_system_scc' and build on it.
+# If not, build on our own SCC.
+if [[ -d "/opt/java/.scc" ]] && [[ `stat -L -c "%a" "/opt/java/.scc" | cut -c 1,2` == "77" ]]
+then
+  SCC="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc"
+else
+  SCC="-Xshareclasses:name=liberty,cacheDir=/output/.classCache"
+fi
+
 # For JDK8, as of OpenJ9 0.20.0 the criteria for determining the max heap size (-Xmx) has changed
 # and the JVM has freedom to choose larger max heap sizes.
 # Currently in compressedrefs mode there is a dependency between heap size and position and the AOT code stored in the
@@ -17,7 +26,8 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode $SCC"
+export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
 PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"

--- a/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk11
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk8
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/beta/helpers/build/populate_scc.sh
+++ b/releases/latest/beta/helpers/build/populate_scc.sh
@@ -9,6 +9,15 @@ SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
+# If this directory exists and has at least ug=rwx permissions, assume the base image includes an SCC called 'openj9_system_scc' and build on it.
+# If not, build on our own SCC.
+if [[ -d "/opt/java/.scc" ]] && [[ `stat -L -c "%a" "/opt/java/.scc" | cut -c 1,2` == "77" ]]
+then
+  SCC="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc"
+else
+  SCC="-Xshareclasses:name=liberty,cacheDir=/output/.classCache"
+fi
+
 # For JDK8, as of OpenJ9 0.20.0 the criteria for determining the max heap size (-Xmx) has changed
 # and the JVM has freedom to choose larger max heap sizes.
 # Currently in compressedrefs mode there is a dependency between heap size and position and the AOT code stored in the
@@ -17,7 +26,8 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode $SCC"
+export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
 PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
@@ -82,8 +82,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk15
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk15
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk15
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk15
@@ -82,8 +82,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
@@ -82,8 +82,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/full/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/full/Dockerfile.ubi.ibmjava8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk11
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk11
@@ -81,8 +81,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=2f6056b60d3930b92afe2ffd7b25a63ad648a1db
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
@@ -81,8 +81,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/full/helpers/build/populate_scc.sh
+++ b/releases/latest/full/helpers/build/populate_scc.sh
@@ -9,6 +9,15 @@ SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
+# If this directory exists and has at least ug=rwx permissions, assume the base image includes an SCC called 'openj9_system_scc' and build on it.
+# If not, build on our own SCC.
+if [[ -d "/opt/java/.scc" ]] && [[ `stat -L -c "%a" "/opt/java/.scc" | cut -c 1,2` == "77" ]]
+then
+  SCC="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc"
+else
+  SCC="-Xshareclasses:name=liberty,cacheDir=/output/.classCache"
+fi
+
 # For JDK8, as of OpenJ9 0.20.0 the criteria for determining the max heap size (-Xmx) has changed
 # and the JVM has freedom to choose larger max heap sizes.
 # Currently in compressedrefs mode there is a dependency between heap size and position and the AOT code stored in the
@@ -17,7 +26,8 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode $SCC"
+export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
 PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk11
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk11
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk15
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk15
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk15
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk15
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk8
@@ -83,8 +83,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk11
@@ -82,8 +82,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk11
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
@@ -4,6 +4,7 @@ ARG LIBERTY_SHA=dc007b60e40daa829489b15d5ba264d6e61d94ea
 ARG LIBERTY_BUILD_LABEL=cl201120201014-1215
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG OPENJ9_SCC=true
+ARG VERBOSE=false
 
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="Open Liberty" \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
@@ -82,8 +82,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/releases/latest/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel-slim/helpers/build/populate_scc.sh
@@ -9,6 +9,15 @@ SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 
+# If this directory exists and has at least ug=rwx permissions, assume the base image includes an SCC called 'openj9_system_scc' and build on it.
+# If not, build on our own SCC.
+if [[ -d "/opt/java/.scc" ]] && [[ `stat -L -c "%a" "/opt/java/.scc" | cut -c 1,2` == "77" ]]
+then
+  SCC="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc"
+else
+  SCC="-Xshareclasses:name=liberty,cacheDir=/output/.classCache"
+fi
+
 # For JDK8, as of OpenJ9 0.20.0 the criteria for determining the max heap size (-Xmx) has changed
 # and the JVM has freedom to choose larger max heap sizes.
 # Currently in compressedrefs mode there is a dependency between heap size and position and the AOT code stored in the
@@ -17,7 +26,8 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode $SCC"
+export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
 PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"

--- a/samples/spring-petclinic/Dockerfile
+++ b/samples/spring-petclinic/Dockerfile
@@ -23,5 +23,6 @@ RUN features.sh
 COPY --from=staging /staging/lib.index.cache /lib.index.cache
 COPY --from=staging /staging/myThinApp.jar /config/dropins/spring/myThinApp.jar
 
+ARG VERBOSE=false
 # This script will add the requested server configurations, apply any iFixes and populate caches to optimize runtime
 RUN configure.sh


### PR DESCRIPTION
This PR contains the following:

1. Add VERBOSE build arg where needed
Some Dockerfiles have it as a build arg while others don't. This patch adds it to all such files to be consistent and make debugging more convenient.

2. Build on OpenJ9 system SCC when possible
If the JDK image contains an OpenJ9 SCC that is accessible (the most recent OpenJ9 images), build on it, otherwise continue to build on the Liberty SCC (IBM JDK images and older OpenJ9 images with incorrect SCC directory permissions).