### PR TITLE
Add config dropins and app directories 

### DIFF
--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
@@ -56,6 +56,8 @@ RUN mkdir /logs \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
     && ln -s /opt/ol/wlp /liberty \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk15
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk15
@@ -56,6 +56,8 @@ RUN mkdir /logs \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
     && ln -s /opt/ol/wlp /liberty \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
@@ -56,6 +56,8 @@ RUN mkdir /logs \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
     && ln -s /opt/ol/wlp /liberty \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \

--- a/releases/latest/full/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/full/Dockerfile.ubi.ibmjava8
@@ -56,6 +56,8 @@ RUN mkdir /logs \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
     && ln -s /opt/ol/wlp /liberty \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk11
@@ -55,6 +55,8 @@ RUN mkdir /logs \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
     && ln -s /opt/ol/wlp /liberty \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
@@ -55,6 +55,8 @@ RUN mkdir /logs \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
     && ln -s /opt/ol/wlp /liberty \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \


### PR DESCRIPTION
Signed-off-by: leochr <leojc@ca.ibm.com>

To keep consistent with previous behaviour of `full` images, create dropins and apps directory under /config.