### PR TITLE
Reduce SCC build time for app images

### DIFF
--- a/releases/latest/beta/helpers/build/configure.sh
+++ b/releases/latest/beta/helpers/build/configure.sh
@@ -97,7 +97,7 @@ function main() {
 
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh
+    populate_scc.sh -i 1
   fi
 }
 

--- a/releases/latest/full/helpers/build/configure.sh
+++ b/releases/latest/full/helpers/build/configure.sh
@@ -97,7 +97,7 @@ function main() {
 
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh
+    populate_scc.sh -i 1
   fi
 }
 

--- a/releases/latest/kernel-slim/helpers/build/configure.sh
+++ b/releases/latest/kernel-slim/helpers/build/configure.sh
@@ -5,7 +5,7 @@ if [ "$VERBOSE" != "true" ]; then
 fi
 
 set -Eeox pipefail
-  
+
 function main() {
   ##Define variables for XML snippets source and target paths
   WLP_INSTALL_DIR=/opt/ol/wlp
@@ -25,7 +25,7 @@ function main() {
    cp ${SNIPPETS_SOURCE}/infinispan-client-sessioncache.xml ${SNIPPETS_TARGET}/infinispan-client-sessioncache.xml
    chmod g+rw $SNIPPETS_TARGET/infinispan-client-sessioncache.xml
   fi
-  
+
   # Hazelcast Session Caching
   if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]; then
     cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
@@ -56,7 +56,7 @@ function main() {
 
   # Create a new SCC layer. This should be invoked when server configuration is complete.
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh
+    populate_scc.sh -i 1
   fi
 }
 


### PR DESCRIPTION
Currently every image in the stack runs the server 4 times to build its SCC layer. The final 2 iterations are optional but allow for the refinement of profiling information. This patch reduces the number of optional iterations for **app images** from 2 to 1 to reduce build times on the basis that it does not sacrifice much, if any, start-up performance. It does not affect the number of iterations used for server SCC layers.

### Build time
Time spent in `configure.sh`
(seconds, avg of 3 builds) 
| app | current | w/ patch | delta |
| --- | --- | --- | --- |
| [acmeair-authservice-java](https://github.com/blueperf/acmeair-authservice-java) | 6.798 | 5.203 | -23.46% |
| [sample.daytrader7](https://github.com/WASdev/sample.daytrader7) | 36.568 | 29.125 | -20.35% |

### Start-up time
(seconds, avg of 3 runs)
| app | current | w/ patch | delta |
| --- | --- | --- | --- |
| acmeair-authservice-java | 0.512 | 0.517 | +0.98% |
| sample.daytrader7 | 5.481 | 5.482 |+0.02% |

Evaluated on an x86-64 host using the latest images as of this PR.