### PR TITLE
Set OPENJ9_JAVA_OPTIONS env var for containers

### DIFF
--- a/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk11
@@ -87,7 +87,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk8
@@ -87,7 +87,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
@@ -88,7 +88,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk15
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk15
@@ -88,7 +88,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
@@ -88,7 +88,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk11
@@ -87,7 +87,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
@@ -87,7 +87,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk11
@@ -87,7 +87,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk15
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk15
@@ -87,7 +87,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk8
@@ -87,7 +87,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk11
@@ -86,7 +86,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
@@ -86,7 +86,8 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ol/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 USER 1001
 


### PR DESCRIPTION
Previously OpenJ9 Docker images set OPENJ9_JAVA_OPTIONS to a value
that enabled the use of the system SCC at runtime. Recent OpenJ9 images
have stopped setting it in favour of JAVA_TOOL_OPTIONS, which Liberty is
currently not aware of. This causes the Liberty server script to set
OPENJ9_JAVA_OPTIONS to a default value that does not include the system
SCC.

Fixes #234