### PR TITLE
Remove command to rm non-existent directory

### DIFF
--- a/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk11
@@ -49,7 +49,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create --template=javaee8 \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \

--- a/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/beta/Dockerfile.ubuntu.adoptopenjdk8
@@ -49,7 +49,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create --template=javaee8 \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk11
@@ -50,7 +50,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create --template=javaee8 \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk15
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk15
@@ -50,7 +50,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create --template=javaee8 \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \

--- a/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubi.adoptopenjdk8
@@ -50,7 +50,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create --template=javaee8 \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \

--- a/releases/latest/full/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/full/Dockerfile.ubi.ibmjava8
@@ -50,7 +50,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create --template=javaee8 \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk11
@@ -49,7 +49,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create --template=javaee8 \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \

--- a/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.adoptopenjdk8
@@ -49,7 +49,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create --template=javaee8 \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk11
@@ -50,7 +50,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 
 # Create symlinks && set permissions for non-root user

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk15
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk15
@@ -50,7 +50,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 
 # Create symlinks && set permissions for non-root user

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk8
@@ -50,7 +50,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 
 # Create symlinks && set permissions for non-root user

--- a/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -50,7 +50,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 
 # Create symlinks && set permissions for non-root user

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk11
@@ -49,7 +49,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 
 # Create symlinks && set permissions for non-root user

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
@@ -49,7 +49,7 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache
 
 
 # Create symlinks && set permissions for non-root user


### PR DESCRIPTION
At the point in the dockerfiles where /output/workarea is removed, the directory doesn't exist, as /output is a symlink that hasn't been created yet.
However, removing the real workarea directory slows down server startup, so fix up the dockerfiles by removing the duff command (rather than correcting it to remove the real workarea directory)