### PR TITLE
Delete workarea after SCC run to ensure old server config gets loaded.

### DIFF
--- a/build/buildAll.sh
+++ b/build/buildAll.sh
@@ -28,6 +28,10 @@ done < "$currentRelease/images.txt"
 
 if [[ $currentRelease =~ latest ]]
 then
+  # Expose issues relating to Liberty config caching
+  echo "Update stock quote test with old 20140101 config "
+  touch -t 201401010000.00 test-stock-quote/config/server.xml test-stock-quote/config/configDropins/defaults/keystore.xml
+
   #Test the image
   for test in "${tests[@]}"; do
     testBuild="./build.sh --dir=$test --dockerfile=Dockerfile --tag=$test"

--- a/build/test-stock-quote/config/server.xml
+++ b/build/test-stock-quote/config/server.xml
@@ -16,7 +16,6 @@
         <feature>microProfile-2.2</feature>
         <feature>appSecurity-2.0</feature>
         <feature>monitor-1.0</feature>
-        <feature>jsp-2.3</feature>
 <!--    <feature>ldapRegistry-3.0</feature>      -->
 <!--    <feature>logstashCollector-1.0</feature> -->
     </featureManager>

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk11
@@ -82,7 +82,7 @@ RUN mkdir /logs \
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
-    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk15
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk15
@@ -82,7 +82,7 @@ RUN mkdir /logs \
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
-    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.adoptopenjdk8
@@ -82,7 +82,7 @@ RUN mkdir /logs \
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
-    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -82,7 +82,7 @@ RUN mkdir /logs \
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
-    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk11
@@ -81,7 +81,7 @@ RUN mkdir /logs \
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
-    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.adoptopenjdk8
@@ -81,7 +81,7 @@ RUN mkdir /logs \
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
-    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output
 


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Fixes #244 