### PR TITLE
Adding UBI min tags

### DIFF
--- a/releases/latest/full/Dockerfile.ubimin.openjdk11.jre
+++ b/releases/latest/full/Dockerfile.ubimin.openjdk11.jre
@@ -1,0 +1,99 @@
+FROM ibmsemeruruntime/open-11-jdk:ubi_min-jre
+ARG LIBERTY_VERSION=21.0.0.11
+ARG LIBERTY_SHA=e7d441888396a6e7b493e21b4af870aeac901183
+ARG LIBERTY_BUILD_LABEL=cl21.0.0.11920-1900
+ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
+ARG LIBERTY_LICENSE_URL=https://raw.githubusercontent.com/OpenLiberty/open-liberty/master/LICENSE
+ARG LIBERTY_LICENSE_SHA=84f00503d6516c91190de866e78d6010899673b7
+ARG OPENJ9_SCC=true
+ARG VERBOSE=false
+
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.version="$LIBERTY_VERSION" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL" \
+      vendor="Open Liberty" \
+      name="Open Liberty" \
+      version="$LIBERTY_VERSION" \
+      summary="Image for Open Liberty with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and UBI 8" \
+      description="This image contains the Open Liberty runtime with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and Red Hat UBI 8 as the base OS.  For more information on this image please see https://github.com/OpenLiberty/ci.docker#building-an-application-image"
+
+COPY helpers /opt/ol/helpers
+COPY fixes/ /opt/ol/fixes/
+
+# Install Open Liberty
+RUN microdnf -y install shadow-utils wget unzip openssl \
+    && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
+    && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
+    && sha1sum -c /tmp/wlp.zip.sha1 \
+    && chmod -R u+x /usr/bin \
+    && unzip -q /tmp/wlp.zip -d /opt/ol \
+    && rm /tmp/wlp.zip \
+    && rm /tmp/wlp.zip.sha1 \
+    && mkdir -p /licenses \
+    && wget -q $LIBERTY_LICENSE_URL -O /licenses/LICENSE \
+    && echo "$LIBERTY_LICENSE_SHA /licenses/LICENSE" | sha1sum -c --strict --check \
+    && adduser -u 1001 -r -g root -s /usr/sbin/nologin default \
+    && microdnf -y remove shadow-utils wget unzip \
+    && microdnf clean all \
+    && chown -R 1001:0 /opt/ol/wlp \
+    && chmod -R g+rw /opt/ol/wlp
+
+# Set Path Shortcuts
+ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+    LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ol/wlp/output \
+    WLP_SKIP_MAXPERMSIZE=true \
+    OPENJ9_SCC=$OPENJ9_SCC
+
+# Configure Open Liberty
+RUN /opt/ol/wlp/bin/server create --template=javaee8 \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+# Create symlinks && set permissions for non-root user
+RUN mkdir /logs \
+    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+    && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
+    && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
+    && ln -s /opt/ol/wlp /liberty \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /opt/ol/wlp/usr \
+    && chmod -R g+rw /opt/ol/wlp/usr \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rw /opt/ol/wlp/output \
+    && chown -R 1001:0 /opt/ol/helpers \
+    && chmod -R g+rw /opt/ol/helpers \
+    && chown -R 1001:0 /opt/ol/fixes \
+    && chmod -R g+rwx /opt/ol/fixes \
+    && mkdir /etc/wlp \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal -Dosgi.checkConfiguration=false"
+
+USER 1001
+
+EXPOSE 9080 9443
+
+ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/releases/latest/images.txt
+++ b/releases/latest/images.txt
@@ -1,10 +1,12 @@
 kernel-slim      Dockerfile.ubuntu.openjdk8    open-liberty    		          kernel-slim-java8-openj9            kernel-slim
 kernel-slim      Dockerfile.ubuntu.openjdk11   open-liberty    		          kernel-slim-java11-openj9         
 kernel-slim      Dockerfile.ubi.openjdk8       openliberty/open-liberty      kernel-slim-java8-openj9-ubi        kernel-slim-ubi    
-kernel-slim      Dockerfile.ubi.openjdk11      openliberty/open-liberty      kernel-slim-java11-openj9-ubi        
+kernel-slim      Dockerfile.ubi.openjdk11      openliberty/open-liberty      kernel-slim-java11-openj9-ubi   
+kernel-slim      Dockerfile.ubimin.openjdk11.jre      openliberty/open-liberty      kernel-slim-java11-ubi-min             
 full             Dockerfile.ubuntu.openjdk8    open-liberty     		          full-java8-openj9                   full              
 full             Dockerfile.ubuntu.openjdk11   open-liberty     		          full-java11-openj9                
 full             Dockerfile.ubi.openjdk8       openliberty/open-liberty      full-java8-openj9-ubi               full-ubi         
 full             Dockerfile.ubi.openjdk11      openliberty/open-liberty      full-java11-openj9-ubi                  
+full             Dockerfile.ubimin.openjdk11.jre      openliberty/open-liberty      full-java11-ubi-min               
 beta             Dockerfile.ubuntu.openjdk8    open-liberty    		          beta-java8-openj9                   beta
 beta             Dockerfile.ubuntu.openjdk11   open-liberty                  beta-java11-openj9                  beta-java11

--- a/releases/latest/kernel-slim/Dockerfile.ubimin.openjdk11.jre
+++ b/releases/latest/kernel-slim/Dockerfile.ubimin.openjdk11.jre
@@ -1,0 +1,98 @@
+FROM ibmsemeruruntime/open-11-jdk:ubi_min-jre
+ARG LIBERTY_VERSION=21.0.0.11
+ARG LIBERTY_SHA=bf7d3b1ce093dca85005e0cbbe655dabe6ef96ea
+ARG LIBERTY_BUILD_LABEL=cl21.0.0.11920-1900
+ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
+ARG LIBERTY_LICENSE_URL=https://raw.githubusercontent.com/OpenLiberty/open-liberty/master/LICENSE
+ARG LIBERTY_LICENSE_SHA=84f00503d6516c91190de866e78d6010899673b7
+ARG OPENJ9_SCC=true
+ARG VERBOSE=false
+
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.version="$LIBERTY_VERSION" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL" \
+      vendor="Open Liberty" \
+      name="Open Liberty" \
+      version="$LIBERTY_VERSION" \
+      summary="Image for Open Liberty with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and UBI Min 8" \
+      description="This image contains the Open Liberty runtime with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and Red Hat UBI 8 as the base OS.  For more information on this image please see https://github.com/OpenLiberty/ci.docker#building-an-application-image"
+
+COPY helpers /opt/ol/helpers
+COPY fixes/ /opt/ol/fixes/
+
+# Install Open Liberty
+RUN microdnf -y install shadow-utils wget unzip openssl \
+    && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
+    && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
+    && sha1sum -c /tmp/wlp.zip.sha1 \
+    && chmod -R u+x /usr/bin \
+    && unzip -q /tmp/wlp.zip -d /opt/ol \
+    && rm /tmp/wlp.zip \
+    && rm /tmp/wlp.zip.sha1 \
+    && mkdir -p /licenses \
+    && wget -q $LIBERTY_LICENSE_URL -O /licenses/LICENSE \
+    && echo "$LIBERTY_LICENSE_SHA /licenses/LICENSE" | sha1sum -c --strict --check \
+    && adduser -u 1001 -r -g root -s /usr/sbin/nologin default \
+    && microdnf -y remove shadow-utils wget unzip \
+    && microdnf clean all \
+    && chown -R 1001:0 /opt/ol/wlp \
+    && chmod -R g+rw /opt/ol/wlp
+
+# Set Path Shortcuts
+ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+    LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ol/wlp/output \
+    WLP_SKIP_MAXPERMSIZE=true \
+    OPENJ9_SCC=$OPENJ9_SCC
+
+# Configure Open Liberty
+RUN /opt/ol/wlp/bin/server create \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+
+# Create symlinks && set permissions for non-root user
+RUN mkdir /logs \
+    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+    && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
+    && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && ln -s /opt/ol/wlp /liberty \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /opt/ol/wlp/usr \
+    && chmod -R g+rw /opt/ol/wlp/usr \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rw /opt/ol/wlp/output \
+    && chown -R 1001:0 /opt/ol/helpers \
+    && chmod -R g+rw /opt/ol/helpers \
+    && chown -R 1001:0 /opt/ol/fixes \
+    && chmod -R g+rwx /opt/ol/fixes \
+    && mkdir /etc/wlp \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal -Dosgi.checkConfiguration=false"
+
+USER 1001
+
+EXPOSE 9080 9443
+
+ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]


### PR DESCRIPTION
Adding new tags for UBI min.  FIxes #207 

The new tags are using UBI min and JRE, for Java 11 only.  Here are the comparisons with the current Java 11 tags:

```
REPOSITORY                 TAG                             IMAGE ID       CREATED              SIZE
openliberty/open-liberty   full-java11-openj9-ubi          ceefc6e5456e   About a minute ago   912MB
openliberty/open-liberty   full-java11-ubi-min             ace348c2804d   3 minutes ago        551MB
openliberty/open-liberty   kernel-slim-java11-openj9-ubi   46f96666b5a3   2 hours ago          681MB
openliberty/open-liberty   kernel-slim-java11-ubi-min      20fad0cf3411   3 hours ago          321MB
```

For `kernel-slim` we're seeing a reduction of 52.9% and for `full` the reduction is of 39.6%.

Signed-off-by: Arthur De Magalhaes <ademagalhaes@gmail.com>