### PR TITLE
Provide a Dockerfile for Open Liberty 22.0.0.1 full with ubuntu and Java 17

### DIFF
--- a/releases/22.0.0.1/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.1/full/Dockerfile.ubuntu.openjdk17
@@ -1,5 +1,4 @@
-#FROM ibm-semeru-runtimes:open-11-jre-focal
-FROM cr-global.apps.oc4.denis.prive/ibm-semeru-runtimes:open-17-jre-focal
+FROM ibm-semeru-runtimes:open-17-jre-focal
 ARG LIBERTY_VERSION=22.0.0.1
 ARG LIBERTY_SHA=9a5acc514c26ad91dadf9a21e5c61a090abf0dc9
 ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900

--- a/releases/22.0.0.1/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.1/full/Dockerfile.ubuntu.openjdk17
@@ -1,0 +1,99 @@
+#FROM ibm-semeru-runtimes:open-11-jre-focal
+FROM cr-global.apps.oc4.denis.prive/ibm-semeru-runtimes:open-17-jre-focal
+ARG LIBERTY_VERSION=22.0.0.1
+ARG LIBERTY_SHA=9a5acc514c26ad91dadf9a21e5c61a090abf0dc9
+ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900
+ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
+ARG LIBERTY_LICENSE_URL=https://raw.githubusercontent.com/OpenLiberty/open-liberty/master/LICENSE
+ARG LIBERTY_LICENSE_SHA=84f00503d6516c91190de866e78d6010899673b7
+ARG OPENJ9_SCC=true
+ARG VERBOSE=false
+
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
+      org.opencontainers.image.vendor="Open Liberty" \
+      org.opencontainers.image.url="https://openliberty.io/" \
+      org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
+      org.opencontainers.image.revision="$LIBERTY_BUILD_LABEL" \
+      org.opencontainers.image.description="This image contains the Open Liberty runtime with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and Ubuntu as the base OS.  For more information on this image please see https://github.com/OpenLiberty/ci.docker#building-an-application-image" \
+      org.opencontainers.image.title="Open Liberty" \
+      org.opencontainers.image.version="$LIBERTY_VERSION"
+
+COPY helpers /opt/ol/helpers
+COPY fixes/ /opt/ol/fixes/
+
+# Install Open Liberty
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip openssl wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget -q $LIBERTY_DOWNLOAD_URL -U UA-Open-Liberty-Docker -O /tmp/wlp.zip \
+    && echo "$LIBERTY_SHA  /tmp/wlp.zip" > /tmp/wlp.zip.sha1 \
+    && sha1sum -c /tmp/wlp.zip.sha1 \
+    && unzip -q /tmp/wlp.zip -d /opt/ol \
+    && rm /tmp/wlp.zip \
+    && rm /tmp/wlp.zip.sha1 \
+    && mkdir -p /licenses \
+    && wget -q $LIBERTY_LICENSE_URL -O /licenses/LICENSE \
+    && echo "$LIBERTY_LICENSE_SHA /licenses/LICENSE" | sha1sum -c --strict --check \
+    && apt-get remove -y unzip \
+    && apt-get remove -y wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
+    && chown -R 1001:0 /opt/ol/wlp \
+    && chmod -R g+rw /opt/ol/wlp
+
+# Set Path Shortcuts
+ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+    LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ol/wlp/output \
+    WLP_SKIP_MAXPERMSIZE=true \
+    OPENJ9_SCC=$OPENJ9_SCC
+
+# Configure Open Liberty
+RUN /opt/ol/wlp/bin/server create --template=javaee8 \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+# Create symlinks && set permissions for non-root user
+RUN mkdir /logs \
+    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+    && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
+    && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
+    && ln -s /opt/ol/wlp /liberty \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /opt/ol/wlp/usr \
+    && chmod -R g+rw /opt/ol/wlp/usr \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rw /opt/ol/wlp/output \
+    && chown -R 1001:0 /opt/ol/helpers \
+    && chmod -R g+rw /opt/ol/helpers \
+    && chown -R 1001:0 /opt/ol/fixes \
+    && chmod -R g+rwx /opt/ol/fixes \
+    && mkdir /etc/wlp \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rwx /opt/ol/wlp/output
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal -Dosgi.checkConfiguration=false"
+
+USER 1001
+
+EXPOSE 9080 9443
+
+ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]


### PR DESCRIPTION
This PR adds the`"Dockerfile.ubuntu.openjdk17"`file  to build a container image with Open Liberty and Java 17

It's a clone of`"Dockerfile.ubuntu.openjdk11"`with the base image changed from`"ibm-semeru-runtimes:open-11-jre-focal"` to `"ibm-semeru-runtimes:open-17-jre-focal"`