### PR TITLE
Provide a Dockerfile for Open Liberty with icr.io UBI images and Java 17

### DIFF
--- a/releases/21.0.0.12/full/Dockerfile.ubi.openjdk11
+++ b/releases/21.0.0.12/full/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 ARG LIBERTY_VERSION=21.0.0.12
 ARG LIBERTY_SHA=85635806bc4acc7192ea4d542d67462182e8fa3b
 ARG LIBERTY_BUILD_LABEL=cl21.0.0.12920-1900

--- a/releases/21.0.0.12/full/Dockerfile.ubi.openjdk17
+++ b/releases/21.0.0.12/full/Dockerfile.ubi.openjdk17
@@ -1,14 +1,14 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
 ARG LIBERTY_VERSION=21.0.0.12
-ARG LIBERTY_SHA=101f7be5f15f14a4a3dabc74dd106be2e743245e
+ARG LIBERTY_SHA=85635806bc4acc7192ea4d542d67462182e8fa3b
 ARG LIBERTY_BUILD_LABEL=cl21.0.0.12920-1900
-ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
+ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_LICENSE_URL=https://raw.githubusercontent.com/OpenLiberty/open-liberty/master/LICENSE
 ARG LIBERTY_LICENSE_SHA=84f00503d6516c91190de866e78d6010899673b7
 ARG OPENJ9_SCC=true
 ARG VERBOSE=false
 
-LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
+LABEL org.opencontainers.image.authors="Chris Potter, Leo Christy Jesuraj, Melissa Lee" \
       org.opencontainers.image.vendor="Open Liberty" \
       org.opencontainers.image.url="https://openliberty.io/" \
       org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
@@ -49,9 +49,8 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure Open Liberty
-RUN /opt/ol/wlp/bin/server create \
+RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
-
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
@@ -62,6 +61,8 @@ RUN mkdir /logs \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
     && ln -s /opt/ol/wlp /liberty \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
@@ -82,7 +83,7 @@ RUN mkdir /logs \
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
-    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output
 

--- a/releases/21.0.0.12/full/Dockerfile.ubi.openjdk8
+++ b/releases/21.0.0.12/full/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 ARG LIBERTY_VERSION=21.0.0.12
 ARG LIBERTY_SHA=85635806bc4acc7192ea4d542d67462182e8fa3b
 ARG LIBERTY_BUILD_LABEL=cl21.0.0.12920-1900

--- a/releases/21.0.0.12/images.txt
+++ b/releases/21.0.0.12/images.txt
@@ -3,8 +3,10 @@ kernel-slim      Dockerfile.ubuntu.openjdk11   open-liberty    		          21.0.
 kernel-slim      Dockerfile.ubuntu.openjdk17   open-liberty    		          21.0.0.12-kernel-slim-java17-openj9
 kernel-slim      Dockerfile.ubi.openjdk8       openliberty/open-liberty      21.0.0.12-kernel-slim-java8-openj9-ubi
 kernel-slim      Dockerfile.ubi.openjdk11      openliberty/open-liberty      21.0.0.12-kernel-slim-java11-openj9-ubi
+kernel-slim      Dockerfile.ubi.openjdk17      openliberty/open-liberty      21.0.0.12-kernel-slim-java17-openj9-ubi
 full             Dockerfile.ubuntu.openjdk8    open-liberty     		          21.0.0.12-full-java8-openj9
 full             Dockerfile.ubuntu.openjdk11   open-liberty     		          21.0.0.12-full-java11-openj9
 full             Dockerfile.ubuntu.openjdk17   open-liberty     		          21.0.0.12-full-java17-openj9
 full             Dockerfile.ubi.openjdk8       openliberty/open-liberty      21.0.0.12-full-java8-openj9-ubi
 full             Dockerfile.ubi.openjdk11      openliberty/open-liberty      21.0.0.12-full-java11-openj9-ubi
+full             Dockerfile.ubi.openjdk17      openliberty/open-liberty      21.0.0.12-full-java17-openj9-ubi

--- a/releases/21.0.0.12/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/21.0.0.12/kernel-slim/Dockerfile.ubi.openjdk17
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
 ARG LIBERTY_VERSION=21.0.0.12
 ARG LIBERTY_SHA=101f7be5f15f14a4a3dabc74dd106be2e743245e
 ARG LIBERTY_BUILD_LABEL=cl21.0.0.12920-1900
@@ -8,7 +8,7 @@ ARG LIBERTY_LICENSE_SHA=84f00503d6516c91190de866e78d6010899673b7
 ARG OPENJ9_SCC=true
 ARG VERBOSE=false
 
-LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
+LABEL org.opencontainers.image.authors="Chris Potter, Leo Christy Jesuraj, Melissa Lee" \
       org.opencontainers.image.vendor="Open Liberty" \
       org.opencontainers.image.url="https://openliberty.io/" \
       org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \

--- a/releases/21.0.0.12/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/21.0.0.12/kernel-slim/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 ARG LIBERTY_VERSION=21.0.0.12
 ARG LIBERTY_SHA=101f7be5f15f14a4a3dabc74dd106be2e743245e
 ARG LIBERTY_BUILD_LABEL=cl21.0.0.12920-1900

--- a/releases/21.0.0.9/full/Dockerfile.ubi.openjdk11
+++ b/releases/21.0.0.9/full/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 ARG LIBERTY_VERSION=21.0.0.9
 ARG LIBERTY_SHA=102958ae6e070c29a7b5c55b4c414953900283fa
 ARG LIBERTY_BUILD_LABEL=cl210920210824-2341

--- a/releases/21.0.0.9/full/Dockerfile.ubi.openjdk8
+++ b/releases/21.0.0.9/full/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 ARG LIBERTY_VERSION=21.0.0.9
 ARG LIBERTY_SHA=102958ae6e070c29a7b5c55b4c414953900283fa
 ARG LIBERTY_BUILD_LABEL=cl210920210824-2341

--- a/releases/21.0.0.9/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/21.0.0.9/kernel-slim/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 ARG LIBERTY_VERSION=21.0.0.9
 ARG LIBERTY_SHA=82894898cdb1824d173c3e87052f93230c163278
 ARG LIBERTY_BUILD_LABEL=cl210920210824-2341

--- a/releases/21.0.0.9/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/21.0.0.9/kernel-slim/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 ARG LIBERTY_VERSION=21.0.0.9
 ARG LIBERTY_SHA=82894898cdb1824d173c3e87052f93230c163278
 ARG LIBERTY_BUILD_LABEL=cl210920210824-2341

--- a/releases/22.0.0.1/full/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.1/full/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 ARG LIBERTY_VERSION=22.0.0.1
 ARG LIBERTY_SHA=9a5acc514c26ad91dadf9a21e5c61a090abf0dc9
 ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900

--- a/releases/22.0.0.1/full/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.1/full/Dockerfile.ubi.openjdk17
@@ -1,14 +1,14 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
-ARG LIBERTY_VERSION=21.0.0.12
-ARG LIBERTY_SHA=101f7be5f15f14a4a3dabc74dd106be2e743245e
-ARG LIBERTY_BUILD_LABEL=cl21.0.0.12920-1900
-ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+ARG LIBERTY_VERSION=22.0.0.1
+ARG LIBERTY_SHA=9a5acc514c26ad91dadf9a21e5c61a090abf0dc9
+ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900
+ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_LICENSE_URL=https://raw.githubusercontent.com/OpenLiberty/open-liberty/master/LICENSE
 ARG LIBERTY_LICENSE_SHA=84f00503d6516c91190de866e78d6010899673b7
 ARG OPENJ9_SCC=true
 ARG VERBOSE=false
 
-LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
+LABEL org.opencontainers.image.authors="Chris Potter, Leo Christy Jesuraj, Melissa Lee" \
       org.opencontainers.image.vendor="Open Liberty" \
       org.opencontainers.image.url="https://openliberty.io/" \
       org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
@@ -49,9 +49,8 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure Open Liberty
-RUN /opt/ol/wlp/bin/server create \
+RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
-
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
@@ -62,6 +61,8 @@ RUN mkdir /logs \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
     && ln -s /opt/ol/wlp /liberty \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
@@ -82,7 +83,7 @@ RUN mkdir /logs \
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
-    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output
 

--- a/releases/22.0.0.1/full/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.1/full/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 ARG LIBERTY_VERSION=22.0.0.1
 ARG LIBERTY_SHA=9a5acc514c26ad91dadf9a21e5c61a090abf0dc9
 ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900

--- a/releases/22.0.0.1/images.txt
+++ b/releases/22.0.0.1/images.txt
@@ -3,8 +3,10 @@ kernel-slim      Dockerfile.ubuntu.openjdk11   open-liberty    		          22.0.
 kernel-slim      Dockerfile.ubuntu.openjdk17   open-liberty    		          22.0.0.1-kernel-slim-java17-openj9
 kernel-slim      Dockerfile.ubi.openjdk8       openliberty/open-liberty      22.0.0.1-kernel-slim-java8-openj9-ubi
 kernel-slim      Dockerfile.ubi.openjdk11      openliberty/open-liberty      22.0.0.1-kernel-slim-java11-openj9-ubi
+kernel-slim      Dockerfile.ubi.openjdk17      openliberty/open-liberty      22.0.0.1-kernel-slim-java17-openj9-ubi
 full             Dockerfile.ubuntu.openjdk8    open-liberty     		          22.0.0.1-full-java8-openj9
 full             Dockerfile.ubuntu.openjdk11   open-liberty     		          22.0.0.1-full-java11-openj9
 full             Dockerfile.ubuntu.openjdk17   open-liberty     		          22.0.0.1-full-java17-openj9
 full             Dockerfile.ubi.openjdk8       openliberty/open-liberty      22.0.0.1-full-java8-openj9-ubi
 full             Dockerfile.ubi.openjdk11      openliberty/open-liberty      22.0.0.1-full-java11-openj9-ubi
+full             Dockerfile.ubi.openjdk17      openliberty/open-liberty      22.0.0.1-full-java17-openj9-ubi

--- a/releases/22.0.0.1/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.1/kernel-slim/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 ARG LIBERTY_VERSION=22.0.0.1
 ARG LIBERTY_SHA=21bc82aa555453d10971d0db2ebee483490e2f19
 ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900

--- a/releases/22.0.0.1/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.1/kernel-slim/Dockerfile.ubi.openjdk17
@@ -1,14 +1,14 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
-ARG LIBERTY_VERSION=21.0.0.12
-ARG LIBERTY_SHA=101f7be5f15f14a4a3dabc74dd106be2e743245e
-ARG LIBERTY_BUILD_LABEL=cl21.0.0.12920-1900
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+ARG LIBERTY_VERSION=22.0.0.1
+ARG LIBERTY_SHA=21bc82aa555453d10971d0db2ebee483490e2f19
+ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG LIBERTY_LICENSE_URL=https://raw.githubusercontent.com/OpenLiberty/open-liberty/master/LICENSE
 ARG LIBERTY_LICENSE_SHA=84f00503d6516c91190de866e78d6010899673b7
 ARG OPENJ9_SCC=true
 ARG VERBOSE=false
 
-LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
+LABEL org.opencontainers.image.authors="Chris Potter, Leo Christy Jesuraj, Melissa Lee" \
       org.opencontainers.image.vendor="Open Liberty" \
       org.opencontainers.image.url="https://openliberty.io/" \
       org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \

--- a/releases/22.0.0.1/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.1/kernel-slim/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 ARG LIBERTY_VERSION=22.0.0.1
 ARG LIBERTY_SHA=21bc82aa555453d10971d0db2ebee483490e2f19
 ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900

--- a/releases/latest/full/Dockerfile.ubi.openjdk11
+++ b/releases/latest/full/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 ARG LIBERTY_VERSION=22.0.0.1
 ARG LIBERTY_SHA=9a5acc514c26ad91dadf9a21e5c61a090abf0dc9
 ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900

--- a/releases/latest/full/Dockerfile.ubi.openjdk17
+++ b/releases/latest/full/Dockerfile.ubi.openjdk17
@@ -1,14 +1,14 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
-ARG LIBERTY_VERSION=21.0.0.12
-ARG LIBERTY_SHA=101f7be5f15f14a4a3dabc74dd106be2e743245e
-ARG LIBERTY_BUILD_LABEL=cl21.0.0.12920-1900
-ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+ARG LIBERTY_VERSION=22.0.0.1
+ARG LIBERTY_SHA=9a5acc514c26ad91dadf9a21e5c61a090abf0dc9
+ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900
+ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_LICENSE_URL=https://raw.githubusercontent.com/OpenLiberty/open-liberty/master/LICENSE
 ARG LIBERTY_LICENSE_SHA=84f00503d6516c91190de866e78d6010899673b7
 ARG OPENJ9_SCC=true
 ARG VERBOSE=false
 
-LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
+LABEL org.opencontainers.image.authors="Chris Potter, Leo Christy Jesuraj, Melissa Lee" \
       org.opencontainers.image.vendor="Open Liberty" \
       org.opencontainers.image.url="https://openliberty.io/" \
       org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \
@@ -49,9 +49,8 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure Open Liberty
-RUN /opt/ol/wlp/bin/server create \
+RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
-
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
@@ -62,6 +61,8 @@ RUN mkdir /logs \
     && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
+    && mkdir -p /config/dropins \
+    && mkdir -p /config/apps \
     && ln -s /opt/ol/wlp /liberty \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
@@ -82,7 +83,7 @@ RUN mkdir /logs \
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
-    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
     && chown -R 1001:0 /opt/ol/wlp/output \
     && chmod -R g+rwx /opt/ol/wlp/output
 

--- a/releases/latest/full/Dockerfile.ubi.openjdk8
+++ b/releases/latest/full/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 ARG LIBERTY_VERSION=22.0.0.1
 ARG LIBERTY_SHA=9a5acc514c26ad91dadf9a21e5c61a090abf0dc9
 ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900

--- a/releases/latest/images.txt
+++ b/releases/latest/images.txt
@@ -3,11 +3,13 @@ kernel-slim      Dockerfile.ubuntu.openjdk11   open-liberty    		          kerne
 kernel-slim      Dockerfile.ubuntu.openjdk17   open-liberty    		          kernel-slim-java17-openj9         
 kernel-slim      Dockerfile.ubi.openjdk8       openliberty/open-liberty      kernel-slim-java8-openj9-ubi        kernel-slim-ubi    
 kernel-slim      Dockerfile.ubi.openjdk11      openliberty/open-liberty      kernel-slim-java11-openj9-ubi        
+kernel-slim      Dockerfile.ubi.openjdk17      openliberty/open-liberty      kernel-slim-java17-openj9-ubi        
 full             Dockerfile.ubuntu.openjdk8    open-liberty     		          full-java8-openj9                   full              
 full             Dockerfile.ubuntu.openjdk11   open-liberty     		          full-java11-openj9                
 full             Dockerfile.ubuntu.openjdk17   open-liberty     		          full-java17-openj9                
 full             Dockerfile.ubi.openjdk8       openliberty/open-liberty      full-java8-openj9-ubi               full-ubi         
-full             Dockerfile.ubi.openjdk11      openliberty/open-liberty      full-java11-openj9-ubi                  
+full             Dockerfile.ubi.openjdk11      openliberty/open-liberty      full-java11-openj9-ubi                           
+full             Dockerfile.ubi.openjdk17      openliberty/open-liberty      full-java11-openj9-ubi                  
 beta             Dockerfile.ubuntu.openjdk8    open-liberty    		          beta-java8-openj9                   beta
 beta             Dockerfile.ubuntu.openjdk11   open-liberty                  beta-java11-openj9                  beta-java11
 beta             Dockerfile.ubuntu.openjdk17   open-liberty                  beta-java17-openj9                  beta-java17

--- a/releases/latest/images.txt
+++ b/releases/latest/images.txt
@@ -9,7 +9,7 @@ full             Dockerfile.ubuntu.openjdk11   open-liberty     		          full
 full             Dockerfile.ubuntu.openjdk17   open-liberty     		          full-java17-openj9                
 full             Dockerfile.ubi.openjdk8       openliberty/open-liberty      full-java8-openj9-ubi               full-ubi         
 full             Dockerfile.ubi.openjdk11      openliberty/open-liberty      full-java11-openj9-ubi                           
-full             Dockerfile.ubi.openjdk17      openliberty/open-liberty      full-java11-openj9-ubi                  
+full             Dockerfile.ubi.openjdk17      openliberty/open-liberty      full-java17-openj9-ubi                  
 beta             Dockerfile.ubuntu.openjdk8    open-liberty    		          beta-java8-openj9                   beta
 beta             Dockerfile.ubuntu.openjdk11   open-liberty                  beta-java11-openj9                  beta-java11
 beta             Dockerfile.ubuntu.openjdk17   open-liberty                  beta-java17-openj9                  beta-java17

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 ARG LIBERTY_VERSION=22.0.0.1
 ARG LIBERTY_SHA=21bc82aa555453d10971d0db2ebee483490e2f19
 ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
@@ -1,14 +1,14 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
-ARG LIBERTY_VERSION=21.0.0.12
-ARG LIBERTY_SHA=101f7be5f15f14a4a3dabc74dd106be2e743245e
-ARG LIBERTY_BUILD_LABEL=cl21.0.0.12920-1900
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+ARG LIBERTY_VERSION=22.0.0.1
+ARG LIBERTY_SHA=21bc82aa555453d10971d0db2ebee483490e2f19
+ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG LIBERTY_LICENSE_URL=https://raw.githubusercontent.com/OpenLiberty/open-liberty/master/LICENSE
 ARG LIBERTY_LICENSE_SHA=84f00503d6516c91190de866e78d6010899673b7
 ARG OPENJ9_SCC=true
 ARG VERBOSE=false
 
-LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Leo Christy Jesuraj" \
+LABEL org.opencontainers.image.authors="Chris Potter, Leo Christy Jesuraj, Melissa Lee" \
       org.opencontainers.image.vendor="Open Liberty" \
       org.opencontainers.image.url="https://openliberty.io/" \
       org.opencontainers.image.source="https://github.com/OpenLiberty/ci.docker" \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 ARG LIBERTY_VERSION=22.0.0.1
 ARG LIBERTY_SHA=21bc82aa555453d10971d0db2ebee483490e2f19
 ARG LIBERTY_BUILD_LABEL=cl22.0.0.1920-1900


### PR DESCRIPTION
This PR adds Dockerfiles to build container images for Open Liberty with icr.io UBI images and Java 17 (full, slim, beta)