### PR TITLE
Configure Travis to build for ARM64. Closes #241

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: bash
 
 dist: xenial
 
+arch:
+  - amd64
+  - ppc64le
+  - s390x
+  - arm64
+
 os: linux
 
 sudo: required


### PR DESCRIPTION
Closes #241

This is an attempt to build the Docker image for ARM machines (such as recent Macs). I was able to build it [by locally simulating what Travis does](https://github.com/OpenLiberty/ci.docker/issues/241#issuecomment-1035123075), so I assume configuring Travis to run the build on different architectures should be enough? 

Unfortunately I haven't been able to test it, because I can't set up a free Travis CI account. Is anyone able to help test it? @arthurdm @crpotter @NottyCode ?

I'm not sure how you guys update `docker.io/open-liberty`. Do we have to change anything else in the code, or do you push manually?