### PR TITLE
Remove server.env for instanton dockerfile

### DIFF
--- a/releases/latest/beta-instanton/Dockerfile.ubi.openjdk17
+++ b/releases/latest/beta-instanton/Dockerfile.ubi.openjdk17
@@ -125,7 +125,8 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
 
 # Configure Open Liberty
 RUN /opt/ol/wlp/bin/server create --template=javaee8 \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea \
+    && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \


### PR DESCRIPTION
See issue #353 for more details on the performance benefit of removing the generated server.env from the instant on dockerfile.