### PR TITLE
Enable user to specify size of SCC embedded in container

### DIFF
--- a/releases/22.0.0.12/full/helpers/build/configure.sh
+++ b/releases/22.0.0.12/full/helpers/build/configure.sh
@@ -97,7 +97,14 @@ function main() {
 
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh -i 1
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/releases/22.0.0.12/kernel-slim/helpers/build/configure.sh
+++ b/releases/22.0.0.12/kernel-slim/helpers/build/configure.sh
@@ -56,7 +56,14 @@ function main() {
 
   # Create a new SCC layer. This should be invoked when server configuration is complete.
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh -i 1
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/releases/22.0.0.9/full/helpers/build/configure.sh
+++ b/releases/22.0.0.9/full/helpers/build/configure.sh
@@ -97,7 +97,14 @@ function main() {
 
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh -i 1
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/releases/22.0.0.9/kernel-slim/helpers/build/configure.sh
+++ b/releases/22.0.0.9/kernel-slim/helpers/build/configure.sh
@@ -56,7 +56,14 @@ function main() {
 
   # Create a new SCC layer. This should be invoked when server configuration is complete.
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh -i 1
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/releases/23.0.0.1/full/helpers/build/configure.sh
+++ b/releases/23.0.0.1/full/helpers/build/configure.sh
@@ -97,7 +97,14 @@ function main() {
 
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh -i 1
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/releases/23.0.0.1/kernel-slim/helpers/build/configure.sh
+++ b/releases/23.0.0.1/kernel-slim/helpers/build/configure.sh
@@ -56,7 +56,14 @@ function main() {
 
   # Create a new SCC layer. This should be invoked when server configuration is complete.
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh -i 1
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/releases/latest/beta-instanton/helpers/build/configure.sh
+++ b/releases/latest/beta-instanton/helpers/build/configure.sh
@@ -97,7 +97,14 @@ function main() {
 
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh -i 1
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/releases/latest/beta/helpers/build/configure.sh
+++ b/releases/latest/beta/helpers/build/configure.sh
@@ -97,7 +97,14 @@ function main() {
 
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh -i 1
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/releases/latest/full/helpers/build/configure.sh
+++ b/releases/latest/full/helpers/build/configure.sh
@@ -97,7 +97,14 @@ function main() {
 
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh -i 1
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/releases/latest/kernel-slim/helpers/build/configure.sh
+++ b/releases/latest/kernel-slim/helpers/build/configure.sh
@@ -56,7 +56,14 @@ function main() {
 
   # Create a new SCC layer. This should be invoked when server configuration is complete.
   if [ "$OPENJ9_SCC" == "true" ]; then
-    populate_scc.sh -i 1
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 


### PR DESCRIPTION
Users who create container images for their Liberty based apps are encouraged to use "RUN configure.sh" in the Dockerfile for their containerized app. In turn, this script will call `populate_scc.sh` which will create a shared class cached (SCC) populated with Java classes and methods used during app start-up. Currently, the populate_scc.sh script uses a fixed size (80m) for the embedded SCC. Moreover, the variable `TRIM_SCC` that controls whether or not the SCC is trimmed to just the right size for the classes/methods used during start-up is set to "yes".
To take advantage of the AOT cache from the Semeru Cloud Compiler, the client JVM (which runs a Liberty app) needs to have a SCC with some empty space in it, to be able to add new AOT methods received from the Semeru Cloud Compiler.
This commit allows a user to change the default values for the TRIM_SCC and SCC_SIZE variables in order to create a Liberty app container with an embedded SCC that has some free space. To take advantage of this commit, the user would have to add somethig like
	ENV TRIM_SCC=no
	ENV SCC_SIZE=120m
in his Dockerfile, before calling the `configure.sh` script

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>