### PR TITLE
Configure PATH before Liberty binaries

### DIFF
--- a/releases/22.0.0.12/full/Dockerfile.ubi.ibmjava8
+++ b/releases/22.0.0.12/full/Dockerfile.ubi.ibmjava8
@@ -42,7 +42,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \ 
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubi.ibmjava8
+++ b/releases/22.0.0.12/full/Dockerfile.ubi.ibmjava8
@@ -42,7 +42,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \ 
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.12/full/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.12/full/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.12/full/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.12/full/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.12/full/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.12/full/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.12/full/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -42,7 +42,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.12/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubi.ibmjava8
+++ b/releases/22.0.0.13/full/Dockerfile.ubi.ibmjava8
@@ -42,7 +42,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \ 
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubi.ibmjava8
+++ b/releases/22.0.0.13/full/Dockerfile.ubi.ibmjava8
@@ -42,7 +42,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \ 
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.13/full/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.13/full/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.13/full/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.13/full/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.13/full/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.13/full/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.13/full/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -42,7 +42,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.13/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubi.ibmjava8
+++ b/releases/22.0.0.9/full/Dockerfile.ubi.ibmjava8
@@ -42,7 +42,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.9/full/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.9/full/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.9/full/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.9/full/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.9/full/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.9/full/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.9/full/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -42,7 +42,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \ 
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -42,7 +42,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \ 
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk11
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk17
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubi.openjdk8
@@ -42,7 +42,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/22.0.0.9/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -41,7 +41,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/beta-instanton/Dockerfile.ubi.openjdk17
+++ b/releases/latest/beta-instanton/Dockerfile.ubi.openjdk17
@@ -108,7 +108,7 @@ COPY helpers /opt/ol/helpers
 COPY fixes/ /opt/ol/fixes/
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/beta-instanton/Dockerfile.ubi.openjdk17
+++ b/releases/latest/beta-instanton/Dockerfile.ubi.openjdk17
@@ -82,7 +82,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
     rm -rf /tmp/openjdk.tar.xz;
 
 ENV JAVA_HOME=/opt/java/openjdk \
-    PATH="/opt/java/openjdk/bin:$PATH"
+    PATH="$PATH:/opt/java/openjdk/bin"
 ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 # Install Open Liberty

--- a/releases/latest/beta/Dockerfile.ubi.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubi.openjdk17
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/beta/Dockerfile.ubi.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubi.openjdk17
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk11
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk11
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk17
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk17
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk8
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk8
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/full/Dockerfile.ubi.ibmjava8
@@ -39,7 +39,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubi.openjdk11
+++ b/releases/latest/full/Dockerfile.ubi.openjdk11
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubi.openjdk11
+++ b/releases/latest/full/Dockerfile.ubi.openjdk11
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubi.openjdk17
+++ b/releases/latest/full/Dockerfile.ubi.openjdk17
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubi.openjdk17
+++ b/releases/latest/full/Dockerfile.ubi.openjdk17
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubi.openjdk8
+++ b/releases/latest/full/Dockerfile.ubi.openjdk8
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubi.openjdk8
+++ b/releases/latest/full/Dockerfile.ubi.openjdk8
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk11
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk11
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk17
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk17
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk8
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk8
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -39,7 +39,7 @@ RUN yum -y install wget unzip \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
@@ -39,7 +39,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -38,7 +38,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \


### PR DESCRIPTION
- Switch PATH declaration from prepending to appending Liberty binaries
- Remove unused `/opt/ol/docker/` folder in PATH