### PR TITLE
Add ca.crt to keystore, if it exists

### DIFF
--- a/releases/22.0.0.12/full/helpers/runtime/docker-server.sh
+++ b/releases/22.0.0.12/full/helpers/runtime/docker-server.sh
@@ -17,12 +17,22 @@ function importKeyCert() {
   if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
     # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/releases/22.0.0.12/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/22.0.0.12/kernel-slim/helpers/runtime/docker-server.sh
@@ -17,12 +17,22 @@ function importKeyCert() {
   if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
     # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/releases/22.0.0.9/full/helpers/runtime/docker-server.sh
+++ b/releases/22.0.0.9/full/helpers/runtime/docker-server.sh
@@ -17,12 +17,22 @@ function importKeyCert() {
   if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
     # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/releases/22.0.0.9/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/22.0.0.9/kernel-slim/helpers/runtime/docker-server.sh
@@ -17,12 +17,22 @@ function importKeyCert() {
   if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
     # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/releases/23.0.0.1/full/helpers/runtime/docker-server.sh
+++ b/releases/23.0.0.1/full/helpers/runtime/docker-server.sh
@@ -26,12 +26,22 @@ function importKeyCert() {
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
     # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/releases/23.0.0.1/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/23.0.0.1/kernel-slim/helpers/runtime/docker-server.sh
@@ -26,12 +26,22 @@ function importKeyCert() {
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
     # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/releases/latest/beta-instanton/helpers/runtime/docker-server.sh
+++ b/releases/latest/beta-instanton/helpers/runtime/docker-server.sh
@@ -26,12 +26,22 @@ function importKeyCert() {
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
     # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/releases/latest/beta/helpers/runtime/docker-server.sh
+++ b/releases/latest/beta/helpers/runtime/docker-server.sh
@@ -26,12 +26,22 @@ function importKeyCert() {
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
     # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/releases/latest/full/helpers/runtime/docker-server.sh
+++ b/releases/latest/full/helpers/runtime/docker-server.sh
@@ -26,12 +26,22 @@ function importKeyCert() {
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
     # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
@@ -26,12 +26,22 @@ function importKeyCert() {
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
     # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml


### PR DESCRIPTION
Currently when keystore is generated from mounted file and root CA is in separate file (ca.crt) the keystore will have incomplete chain
