### PR TITLE
verify mutli-arch dumb init downloads

### DIFF
--- a/releases/latest/beta/Dockerfile.ubi.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubi.openjdk17
@@ -28,15 +28,19 @@ RUN set -eux; \
     case "${ARCH}" in \
        aarch64|arm64) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_aarch64'; \
+         DUBM_INIT_SHA256=b7d648f97154a99c539b63c55979cd29f005f88430fb383007fe3458340b795e; \
          ;; \
        amd64|x86_64) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64'; \
+         DUBM_INIT_SHA256=e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df; \
          ;; \
        ppc64el|ppc64le) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_ppc64le'; \
+         DUBM_INIT_SHA256=3d15e80e29f0f4fa1fc686b00613a2220bc37e83a35283d4b4cca1fbd0a5609f; \
          ;; \
        s390x) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_s390x'; \
+         DUBM_INIT_SHA256=47e4601b152fc6dcb1891e66c30ecc62a2939fd7ffd1515a7c30f281cfec53b7; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \
@@ -44,6 +48,7 @@ RUN set -eux; \
          ;; \
     esac; \
     curl -LfsSo /usr/bin/dumb-init ${DUMB_INIT_URL}; \
+    echo "${DUBM_INIT_SHA256} */usr/bin/dumb-init" | sha256sum -c -; \
     chmod +x /usr/bin/dumb-init;
 
 # Install Open Liberty

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk11
@@ -20,19 +20,23 @@ COPY fixes/ /opt/ol/fixes/
 
 # Install dumb-init
 RUN set -eux; \
-    ARCH="$(uname -m)"; \
+    ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_aarch64'; \
+         DUBM_INIT_SHA256=b7d648f97154a99c539b63c55979cd29f005f88430fb383007fe3458340b795e; \
          ;; \
        amd64|x86_64) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64'; \
+         DUBM_INIT_SHA256=e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df; \
          ;; \
        ppc64el|ppc64le) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_ppc64le'; \
+         DUBM_INIT_SHA256=3d15e80e29f0f4fa1fc686b00613a2220bc37e83a35283d4b4cca1fbd0a5609f; \
          ;; \
        s390x) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_s390x'; \
+         DUBM_INIT_SHA256=47e4601b152fc6dcb1891e66c30ecc62a2939fd7ffd1515a7c30f281cfec53b7; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \
@@ -40,6 +44,7 @@ RUN set -eux; \
          ;; \
     esac; \
     curl -LfsSo /usr/bin/dumb-init ${DUMB_INIT_URL}; \
+    echo "${DUBM_INIT_SHA256} */usr/bin/dumb-init" | sha256sum -c -; \
     chmod +x /usr/bin/dumb-init;
 
 # Install Open Liberty

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk17
@@ -20,19 +20,23 @@ COPY fixes/ /opt/ol/fixes/
 
 # Install dumb-init
 RUN set -eux; \
-    ARCH="$(uname -m)"; \
+    ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_aarch64'; \
+         DUBM_INIT_SHA256=b7d648f97154a99c539b63c55979cd29f005f88430fb383007fe3458340b795e; \
          ;; \
        amd64|x86_64) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64'; \
+         DUBM_INIT_SHA256=e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df; \
          ;; \
        ppc64el|ppc64le) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_ppc64le'; \
+         DUBM_INIT_SHA256=3d15e80e29f0f4fa1fc686b00613a2220bc37e83a35283d4b4cca1fbd0a5609f; \
          ;; \
        s390x) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_s390x'; \
+         DUBM_INIT_SHA256=47e4601b152fc6dcb1891e66c30ecc62a2939fd7ffd1515a7c30f281cfec53b7; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \
@@ -40,6 +44,7 @@ RUN set -eux; \
          ;; \
     esac; \
     curl -LfsSo /usr/bin/dumb-init ${DUMB_INIT_URL}; \
+    echo "${DUBM_INIT_SHA256} */usr/bin/dumb-init" | sha256sum -c -; \
     chmod +x /usr/bin/dumb-init;
 
 # Install Open Liberty

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk8
@@ -21,19 +21,23 @@ COPY fixes/ /opt/ol/fixes/
 
 # Install dumb-init
 RUN set -eux; \
-    ARCH="$(uname -m)"; \
+    ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_aarch64'; \
+         DUBM_INIT_SHA256=b7d648f97154a99c539b63c55979cd29f005f88430fb383007fe3458340b795e; \
          ;; \
        amd64|x86_64) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64'; \
+         DUBM_INIT_SHA256=e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df; \
          ;; \
        ppc64el|ppc64le) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_ppc64le'; \
+         DUBM_INIT_SHA256=3d15e80e29f0f4fa1fc686b00613a2220bc37e83a35283d4b4cca1fbd0a5609f; \
          ;; \
        s390x) \
          DUMB_INIT_URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_s390x'; \
+         DUBM_INIT_SHA256=47e4601b152fc6dcb1891e66c30ecc62a2939fd7ffd1515a7c30f281cfec53b7; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \
@@ -41,6 +45,7 @@ RUN set -eux; \
          ;; \
     esac; \
     curl -LfsSo /usr/bin/dumb-init ${DUMB_INIT_URL}; \
+    echo "${DUBM_INIT_SHA256} */usr/bin/dumb-init" | sha256sum -c -; \
     chmod +x /usr/bin/dumb-init;
 
 # Install Open Liberty


### PR DESCRIPTION
Addresses the concern raised at https://github.com/docker-library/official-images/pull/14766#issuecomment-1577704525