### PR TITLE
Fail if server cannot start when populating SCC

### DIFF
--- a/releases/23.0.0.3/full/helpers/build/populate_scc.sh
+++ b/releases/23.0.0.3/full/helpers/build/populate_scc.sh
@@ -81,7 +81,8 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
   # Find out how full it is.
   FULL=`( java $PRINT_LAYER_STATS || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
   echo "SCC layer is $FULL% full. Destroying layer."
@@ -104,7 +105,8 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
 done
 
 # restore umask

--- a/releases/23.0.0.3/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/23.0.0.3/kernel-slim/helpers/build/populate_scc.sh
@@ -81,7 +81,8 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
   # Find out how full it is.
   FULL=`( java $PRINT_LAYER_STATS || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
   echo "SCC layer is $FULL% full. Destroying layer."
@@ -104,7 +105,8 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
 done
 
 # restore umask

--- a/releases/23.0.0.6/full/helpers/build/populate_scc.sh
+++ b/releases/23.0.0.6/full/helpers/build/populate_scc.sh
@@ -81,7 +81,8 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
   # Find out how full it is.
   FULL=`( java $PRINT_LAYER_STATS || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
   echo "SCC layer is $FULL% full. Destroying layer."
@@ -104,7 +105,8 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
 done
 
 # restore umask

--- a/releases/23.0.0.6/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/23.0.0.6/kernel-slim/helpers/build/populate_scc.sh
@@ -81,7 +81,8 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
   # Find out how full it is.
   FULL=`( java $PRINT_LAYER_STATS || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
   echo "SCC layer is $FULL% full. Destroying layer."
@@ -104,7 +105,8 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
 done
 
 # restore umask

--- a/releases/latest/beta/helpers/build/populate_scc.sh
+++ b/releases/latest/beta/helpers/build/populate_scc.sh
@@ -81,7 +81,8 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
   # Find out how full it is.
   FULL=`( java $PRINT_LAYER_STATS || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
   echo "SCC layer is $FULL% full. Destroying layer."
@@ -104,7 +105,8 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
 done
 
 # restore umask

--- a/releases/latest/full/helpers/build/populate_scc.sh
+++ b/releases/latest/full/helpers/build/populate_scc.sh
@@ -81,7 +81,8 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
   # Find out how full it is.
   FULL=`( java $PRINT_LAYER_STATS || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
   echo "SCC layer is $FULL% full. Destroying layer."
@@ -104,7 +105,8 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
 done
 
 # restore umask

--- a/releases/latest/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel-slim/helpers/build/populate_scc.sh
@@ -81,7 +81,8 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
   # Find out how full it is.
   FULL=`( java $PRINT_LAYER_STATS || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
   echo "SCC layer is $FULL% full. Destroying layer."
@@ -104,7 +105,8 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop
+  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server stop
 done
 
 # restore umask


### PR DESCRIPTION
If the server fails to start when populating the SCC we should gracefully fail the build. Because the populate_scc.sh script sets the -e shell option, the shell will exit if any command returns non-zero, except in certain cases.

The populate_scc.sh script starts and stops the server in a compound expression using &&, which is one such case where a non-zero return from `server start` will be ignored.

Executing `server start` and `server stop` separately fixes this and has the desired behaviour; if the server fails to start execution will stop and the build will fail, rather than continuing on and leading to undefined behaviour.