### PR TITLE
Switch 23.0.0.7 Ubuntu images back to focal

### DIFF
--- a/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-focal
 
 USER root
 

--- a/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-focal
 
 USER root
 

--- a/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk8
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-8-jre-jammy
+FROM ibm-semeru-runtimes:open-8-jre-focal
 
 USER root
 

--- a/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-focal
 
 USER root
 

--- a/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-focal
 
 USER root
 

--- a/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-8-jre-jammy
+FROM ibm-semeru-runtimes:open-8-jre-focal
 
 USER root
 

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-focal
 
 USER root
 

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-focal
 
 USER root
 

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk8
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-8-jre-jammy
+FROM ibm-semeru-runtimes:open-8-jre-focal
 
 USER root
 

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-focal
 
 USER root
 

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-focal
 
 USER root
 

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk8
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-8-jre-jammy
+FROM ibm-semeru-runtimes:open-8-jre-focal
 
 USER root
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-focal
 
 USER root
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-focal
 
 USER root
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-8-jre-jammy
+FROM ibm-semeru-runtimes:open-8-jre-focal
 
 USER root
 


### PR DESCRIPTION
Semeru JRE images based on Ubuntu jammy (ibm-semeru-runtimes:open-11-jre-jammy) don't support ppc64le. So switch back to focal for now. 