### PR TITLE
Correct the LIBERTY_SHA values in Open Liberty Docker files

### DIFF
--- a/releases/23.0.0.7/full/Dockerfile.ubi.ibmjava8
+++ b/releases/23.0.0.7/full/Dockerfile.ubi.ibmjava8
@@ -3,7 +3,7 @@ FROM ibmjava:8-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/23.0.0.7/full/Dockerfile.ubi.openjdk11
+++ b/releases/23.0.0.7/full/Dockerfile.ubi.openjdk11
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/23.0.0.7/full/Dockerfile.ubi.openjdk17
+++ b/releases/23.0.0.7/full/Dockerfile.ubi.openjdk17
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/23.0.0.7/full/Dockerfile.ubi.openjdk8
+++ b/releases/23.0.0.7/full/Dockerfile.ubi.openjdk8
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk11
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-11-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk17
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-17-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/23.0.0.7/full/Dockerfile.ubuntu.openjdk8
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-8-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/23.0.0.7/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/23.0.0.7/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -3,7 +3,7 @@ FROM ibmjava:8-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/23.0.0.7/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/23.0.0.7/kernel-slim/Dockerfile.ubi.openjdk11
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/23.0.0.7/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/23.0.0.7/kernel-slim/Dockerfile.ubi.openjdk17
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/23.0.0.7/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/23.0.0.7/kernel-slim/Dockerfile.ubi.openjdk8
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-11-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-17-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/23.0.0.7/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-8-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/latest/beta/Dockerfile.ubi.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubi.openjdk17
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.8-beta
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7bd9ae608dec65669dde34c56d93cee4b964cda4
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk11
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-11-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.8-beta
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7bd9ae608dec65669dde34c56d93cee4b964cda4
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk17
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-17-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.8-beta
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7bd9ae608dec65669dde34c56d93cee4b964cda4
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk8
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-8-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.8-beta
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7bd9ae608dec65669dde34c56d93cee4b964cda4
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/latest/full/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/full/Dockerfile.ubi.ibmjava8
@@ -3,7 +3,7 @@ FROM ibmjava:8-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/latest/full/Dockerfile.ubi.openjdk11
+++ b/releases/latest/full/Dockerfile.ubi.openjdk11
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/latest/full/Dockerfile.ubi.openjdk17
+++ b/releases/latest/full/Dockerfile.ubi.openjdk17
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/latest/full/Dockerfile.ubi.openjdk8
+++ b/releases/latest/full/Dockerfile.ubi.openjdk8
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk11
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-11-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk17
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-17-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk8
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-8-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=5816fa6c03eb20c10f2251f5d41cfbccb6341594
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/$LIBERTY_VERSION/openliberty-runtime-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -3,7 +3,7 @@ FROM ibmjava:8-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
@@ -3,7 +3,7 @@ FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi AS getRuntime
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 
 ARG VERBOSE=false

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-11-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-17-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -3,7 +3,7 @@ FROM ibm-semeru-runtimes:open-8-jre-focal
 USER root
 
 ARG LIBERTY_VERSION=23.0.0.7
-ARG LIBERTY_SHA=da39a3ee5e6b4b0d3255bfef95601890afd80709
+ARG LIBERTY_SHA=7d017aab459ed6fb39636d026251038a5f52a186
 ARG LIBERTY_DOWNLOAD_URL=https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/$LIBERTY_VERSION/openliberty-kernel-$LIBERTY_VERSION.zip
 ARG LIBERTY_BUILD_LABEL=cl230720230710-1201
 


### PR DESCRIPTION
The sha sums specified in the LIBERTY_SHA variables are not correct. This PR is to correct those, per what is recorded in

https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/23.0.0.7/openliberty-runtime-23.0.0.7.zip.sha1
https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/23.0.0.7/openliberty-kernel-23.0.0.7.zip.sha1
https://repo1.maven.org/maven2/io/openliberty/beta/openliberty-runtime/23.0.0.8-beta/openliberty-runtime-23.0.0.8-beta.zip.sha1