### PR TITLE
Add flags to prevent keystore/truststore creation

### DIFF
--- a/releases/23.0.0.3/full/helpers/build/configure.sh
+++ b/releases/23.0.0.3/full/helpers/build/configure.sh
@@ -70,18 +70,21 @@ function main() {
     fi
   fi
 
-  # Key Store
-  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+  # Key Store Features
   if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
   fi
 
-  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
-    if [ ! -e $keystorePath ]; then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
-      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  # Key Store
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ]; then
+    if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+      keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+      if [ ! -e $keystorePath ]; then
+        # Generate the keystore.xml
+        export KEYSTOREPWD=$(openssl rand -base64 32)
+        sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+        chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      fi
     fi
   fi
 

--- a/releases/23.0.0.3/kernel-slim/helpers/build/configure.sh
+++ b/releases/23.0.0.3/kernel-slim/helpers/build/configure.sh
@@ -34,13 +34,15 @@ function main() {
   fi
 
   # Key Store
-  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
-  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
-    if [ ! -e $keystorePath ]; then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
-      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ]; then
+    keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+    if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+      if [ ! -e $keystorePath ]; then
+        # Generate the keystore.xml
+        export KEYSTOREPWD=$(openssl rand -base64 32)
+        sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+        chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      fi
     fi
   fi
 

--- a/releases/23.0.0.6/full/helpers/build/configure.sh
+++ b/releases/23.0.0.6/full/helpers/build/configure.sh
@@ -70,18 +70,21 @@ function main() {
     fi
   fi
 
-  # Key Store
-  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+  # Key Store Features
   if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
   fi
 
-  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
-    if [ ! -e $keystorePath ]; then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
-      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  # Key Store
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ]; then
+    if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+      keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+      if [ ! -e $keystorePath ]; then
+        # Generate the keystore.xml
+        export KEYSTOREPWD=$(openssl rand -base64 32)
+        sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+        chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      fi
     fi
   fi
 

--- a/releases/23.0.0.6/full/helpers/runtime/docker-server.sh
+++ b/releases/23.0.0.6/full/helpers/runtime/docker-server.sh
@@ -21,8 +21,9 @@ function importKeyCert() {
   local KEYSTORE_FILE="/output/resources/security/key.p12"
   local TRUSTSTORE_FILE="/output/resources/security/trust.p12"
 
+  
   # Import the private key and certificate into new keystore
-  if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
@@ -47,7 +48,7 @@ function importKeyCert() {
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
     
     # Add mounted CA to the truststore
-    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+    if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
         echo "Found mounted TLS CA certificate, adding to truststore"
         keytool -import -storetype pkcs12 -noprompt -keystore "${TRUSTSTORE_FILE}" -file "${CERT_FOLDER}/${CA_FILE}" \
           -storepass "${TRUSTSTORE_PASSWORD}" -alias "service-ca" >&/dev/null    
@@ -56,7 +57,7 @@ function importKeyCert() {
 
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
-  if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
     mkdir /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
@@ -71,15 +72,17 @@ function importKeyCert() {
   fi
 
   # Add the keystore password to server configuration
-  if [ ! -e $keystorePath ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ ! -e $keystorePath ]; then
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
-  if [ -e $TRUSTSTORE_FILE ]; then
-    setPasswords PASSWORD TRUSTSTORE_PASSWORD
-    sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
-  elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
-    cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ]; then
+    if [ -e $TRUSTSTORE_FILE ]; then
+      setPasswords PASSWORD TRUSTSTORE_PASSWORD
+      sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
+    elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
+      cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+    fi
   fi
 }
 
@@ -128,18 +131,5 @@ fi
 
 
 # Pass on to the real server run
-if [ -d "/output/workarea/checkpoint/image" ]; then
-  # A checkpoint image found; exec dumb-init for signal handling.
-  # Use of dumb-init for PID 1 is required for signal handling because
-  # the restored server process cannot be PID 1.
-  exec dumb-init --rewrite 15:2 -- /opt/ol/helpers/runtime/restore-server.sh "$@"
-elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
-  # Unset WLP_CHECKPOINT so it is not set in the final image after checkpoint.
-  TMP_CHECKPOINT=$WLP_CHECKPOINT
-  unset WLP_CHECKPOINT
-  # A checkpoint action has been requested; run the checkpoint.sh script.
-  checkpoint.sh "$TMP_CHECKPOINT"
-else
-  # The default is to just exec the supplied CMD
-  exec "$@"
-fi
+exec "$@"
+

--- a/releases/23.0.0.6/kernel-slim/helpers/build/configure.sh
+++ b/releases/23.0.0.6/kernel-slim/helpers/build/configure.sh
@@ -34,13 +34,15 @@ function main() {
   fi
 
   # Key Store
-  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
-  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
-    if [ ! -e $keystorePath ]; then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
-      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ]; then
+    if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+      keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+      if [ ! -e $keystorePath ]; then
+        # Generate the keystore.xml
+        export KEYSTOREPWD=$(openssl rand -base64 32)
+        sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+        chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      fi
     fi
   fi
 

--- a/releases/23.0.0.6/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/23.0.0.6/kernel-slim/helpers/runtime/docker-server.sh
@@ -21,8 +21,9 @@ function importKeyCert() {
   local KEYSTORE_FILE="/output/resources/security/key.p12"
   local TRUSTSTORE_FILE="/output/resources/security/trust.p12"
 
+  
   # Import the private key and certificate into new keystore
-  if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
@@ -47,7 +48,7 @@ function importKeyCert() {
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
     
     # Add mounted CA to the truststore
-    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+    if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
         echo "Found mounted TLS CA certificate, adding to truststore"
         keytool -import -storetype pkcs12 -noprompt -keystore "${TRUSTSTORE_FILE}" -file "${CERT_FOLDER}/${CA_FILE}" \
           -storepass "${TRUSTSTORE_PASSWORD}" -alias "service-ca" >&/dev/null    
@@ -56,7 +57,7 @@ function importKeyCert() {
 
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
-  if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
     mkdir /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
@@ -71,15 +72,17 @@ function importKeyCert() {
   fi
 
   # Add the keystore password to server configuration
-  if [ ! -e $keystorePath ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ ! -e $keystorePath ]; then
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
-  if [ -e $TRUSTSTORE_FILE ]; then
-    setPasswords PASSWORD TRUSTSTORE_PASSWORD
-    sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
-  elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
-    cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ]; then
+    if [ -e $TRUSTSTORE_FILE ]; then
+      setPasswords PASSWORD TRUSTSTORE_PASSWORD
+      sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
+    elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
+      cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+    fi
   fi
 }
 
@@ -128,18 +131,5 @@ fi
 
 
 # Pass on to the real server run
-if [ -d "/output/workarea/checkpoint/image" ]; then
-  # A checkpoint image found; exec dumb-init for signal handling.
-  # Use of dumb-init for PID 1 is required for signal handling because
-  # the restored server process cannot be PID 1.
-  exec dumb-init --rewrite 15:2 -- /opt/ol/helpers/runtime/restore-server.sh "$@"
-elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
-  # Unset WLP_CHECKPOINT so it is not set in the final image after checkpoint.
-  TMP_CHECKPOINT=$WLP_CHECKPOINT
-  unset WLP_CHECKPOINT
-  # A checkpoint action has been requested; run the checkpoint.sh script.
-  checkpoint.sh "$TMP_CHECKPOINT"
-else
-  # The default is to just exec the supplied CMD
-  exec "$@"
-fi
+exec "$@"
+

--- a/releases/23.0.0.7/full/helpers/build/configure.sh
+++ b/releases/23.0.0.7/full/helpers/build/configure.sh
@@ -70,18 +70,21 @@ function main() {
     fi
   fi
 
-  # Key Store
-  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+  # Key Store Features
   if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
   fi
 
-  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
-    if [ ! -e $keystorePath ]; then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
-      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  # Key Store
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ]; then
+    if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+      keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+      if [ ! -e $keystorePath ]; then
+        # Generate the keystore.xml
+        export KEYSTOREPWD=$(openssl rand -base64 32)
+        sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+        chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      fi
     fi
   fi
 

--- a/releases/23.0.0.7/full/helpers/runtime/docker-server.sh
+++ b/releases/23.0.0.7/full/helpers/runtime/docker-server.sh
@@ -21,8 +21,9 @@ function importKeyCert() {
   local KEYSTORE_FILE="/output/resources/security/key.p12"
   local TRUSTSTORE_FILE="/output/resources/security/trust.p12"
 
+  
   # Import the private key and certificate into new keystore
-  if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
@@ -47,7 +48,7 @@ function importKeyCert() {
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
     
     # Add mounted CA to the truststore
-    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+    if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
         echo "Found mounted TLS CA certificate, adding to truststore"
         keytool -import -storetype pkcs12 -noprompt -keystore "${TRUSTSTORE_FILE}" -file "${CERT_FOLDER}/${CA_FILE}" \
           -storepass "${TRUSTSTORE_PASSWORD}" -alias "service-ca" >&/dev/null    
@@ -56,7 +57,7 @@ function importKeyCert() {
 
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
-  if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
     mkdir /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
@@ -71,15 +72,17 @@ function importKeyCert() {
   fi
 
   # Add the keystore password to server configuration
-  if [ ! -e $keystorePath ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ ! -e $keystorePath ]; then
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
-  if [ -e $TRUSTSTORE_FILE ]; then
-    setPasswords PASSWORD TRUSTSTORE_PASSWORD
-    sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
-  elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
-    cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ]; then
+    if [ -e $TRUSTSTORE_FILE ]; then
+      setPasswords PASSWORD TRUSTSTORE_PASSWORD
+      sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
+    elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
+      cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+    fi
   fi
 }
 
@@ -128,18 +131,5 @@ fi
 
 
 # Pass on to the real server run
-if [ -d "/output/workarea/checkpoint/image" ]; then
-  # A checkpoint image found; exec dumb-init for signal handling.
-  # Use of dumb-init for PID 1 is required for signal handling because
-  # the restored server process cannot be PID 1.
-  exec dumb-init --rewrite 15:2 -- /opt/ol/helpers/runtime/restore-server.sh "$@"
-elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
-  # Unset WLP_CHECKPOINT so it is not set in the final image after checkpoint.
-  TMP_CHECKPOINT=$WLP_CHECKPOINT
-  unset WLP_CHECKPOINT
-  # A checkpoint action has been requested; run the checkpoint.sh script.
-  checkpoint.sh "$TMP_CHECKPOINT"
-else
-  # The default is to just exec the supplied CMD
-  exec "$@"
-fi
+exec "$@"
+

--- a/releases/23.0.0.7/kernel-slim/helpers/build/configure.sh
+++ b/releases/23.0.0.7/kernel-slim/helpers/build/configure.sh
@@ -34,13 +34,15 @@ function main() {
   fi
 
   # Key Store
-  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
-  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
-    if [ ! -e $keystorePath ]; then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
-      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ]; then
+    if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+      keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+      if [ ! -e $keystorePath ]; then
+        # Generate the keystore.xml
+        export KEYSTOREPWD=$(openssl rand -base64 32)
+        sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+        chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      fi
     fi
   fi
 

--- a/releases/23.0.0.7/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/23.0.0.7/kernel-slim/helpers/runtime/docker-server.sh
@@ -21,8 +21,9 @@ function importKeyCert() {
   local KEYSTORE_FILE="/output/resources/security/key.p12"
   local TRUSTSTORE_FILE="/output/resources/security/trust.p12"
 
+  
   # Import the private key and certificate into new keystore
-  if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
@@ -47,7 +48,7 @@ function importKeyCert() {
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
     
     # Add mounted CA to the truststore
-    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+    if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
         echo "Found mounted TLS CA certificate, adding to truststore"
         keytool -import -storetype pkcs12 -noprompt -keystore "${TRUSTSTORE_FILE}" -file "${CERT_FOLDER}/${CA_FILE}" \
           -storepass "${TRUSTSTORE_PASSWORD}" -alias "service-ca" >&/dev/null    
@@ -56,7 +57,7 @@ function importKeyCert() {
 
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
-  if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
     mkdir /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
@@ -71,15 +72,17 @@ function importKeyCert() {
   fi
 
   # Add the keystore password to server configuration
-  if [ ! -e $keystorePath ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ ! -e $keystorePath ]; then
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
-  if [ -e $TRUSTSTORE_FILE ]; then
-    setPasswords PASSWORD TRUSTSTORE_PASSWORD
-    sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
-  elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
-    cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ]; then
+    if [ -e $TRUSTSTORE_FILE ]; then
+      setPasswords PASSWORD TRUSTSTORE_PASSWORD
+      sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
+    elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
+      cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+    fi
   fi
 }
 
@@ -128,18 +131,5 @@ fi
 
 
 # Pass on to the real server run
-if [ -d "/output/workarea/checkpoint/image" ]; then
-  # A checkpoint image found; exec dumb-init for signal handling.
-  # Use of dumb-init for PID 1 is required for signal handling because
-  # the restored server process cannot be PID 1.
-  exec dumb-init --rewrite 15:2 -- /opt/ol/helpers/runtime/restore-server.sh "$@"
-elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
-  # Unset WLP_CHECKPOINT so it is not set in the final image after checkpoint.
-  TMP_CHECKPOINT=$WLP_CHECKPOINT
-  unset WLP_CHECKPOINT
-  # A checkpoint action has been requested; run the checkpoint.sh script.
-  checkpoint.sh "$TMP_CHECKPOINT"
-else
-  # The default is to just exec the supplied CMD
-  exec "$@"
-fi
+exec "$@"
+

--- a/releases/latest/beta/helpers/build/configure.sh
+++ b/releases/latest/beta/helpers/build/configure.sh
@@ -70,18 +70,21 @@ function main() {
     fi
   fi
 
-  # Key Store
-  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+  # Key Store Features
   if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
   fi
 
-  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
-    if [ ! -e $keystorePath ]; then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
-      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  # Key Store
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ]; then
+    if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+      keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+      if [ ! -e $keystorePath ]; then
+        # Generate the keystore.xml
+        export KEYSTOREPWD=$(openssl rand -base64 32)
+        sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+        chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      fi
     fi
   fi
 

--- a/releases/latest/beta/helpers/runtime/docker-server.sh
+++ b/releases/latest/beta/helpers/runtime/docker-server.sh
@@ -21,8 +21,9 @@ function importKeyCert() {
   local KEYSTORE_FILE="/output/resources/security/key.p12"
   local TRUSTSTORE_FILE="/output/resources/security/trust.p12"
 
+  
   # Import the private key and certificate into new keystore
-  if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
@@ -47,7 +48,7 @@ function importKeyCert() {
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
     
     # Add mounted CA to the truststore
-    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+    if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
         echo "Found mounted TLS CA certificate, adding to truststore"
         keytool -import -storetype pkcs12 -noprompt -keystore "${TRUSTSTORE_FILE}" -file "${CERT_FOLDER}/${CA_FILE}" \
           -storepass "${TRUSTSTORE_PASSWORD}" -alias "service-ca" >&/dev/null    
@@ -56,7 +57,7 @@ function importKeyCert() {
 
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
-  if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
     mkdir /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
@@ -71,15 +72,17 @@ function importKeyCert() {
   fi
 
   # Add the keystore password to server configuration
-  if [ ! -e $keystorePath ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ ! -e $keystorePath ]; then
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
-  if [ -e $TRUSTSTORE_FILE ]; then
-    setPasswords PASSWORD TRUSTSTORE_PASSWORD
-    sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
-  elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
-    cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ]; then
+    if [ -e $TRUSTSTORE_FILE ]; then
+      setPasswords PASSWORD TRUSTSTORE_PASSWORD
+      sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
+    elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
+      cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+    fi
   fi
 }
 
@@ -128,18 +131,5 @@ fi
 
 
 # Pass on to the real server run
-if [ -d "/output/workarea/checkpoint/image" ]; then
-  # A checkpoint image found; exec dumb-init for signal handling.
-  # Use of dumb-init for PID 1 is required for signal handling because
-  # the restored server process cannot be PID 1.
-  exec dumb-init --rewrite 15:2 -- /opt/ol/helpers/runtime/restore-server.sh "$@"
-elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
-  # Unset WLP_CHECKPOINT so it is not set in the final image after checkpoint.
-  TMP_CHECKPOINT=$WLP_CHECKPOINT
-  unset WLP_CHECKPOINT
-  # A checkpoint action has been requested; run the checkpoint.sh script.
-  checkpoint.sh "$TMP_CHECKPOINT"
-else
-  # The default is to just exec the supplied CMD
-  exec "$@"
-fi
+exec "$@"
+

--- a/releases/latest/full/helpers/build/configure.sh
+++ b/releases/latest/full/helpers/build/configure.sh
@@ -70,18 +70,21 @@ function main() {
     fi
   fi
 
-  # Key Store
-  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+  # Key Store Features
   if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
   fi
 
-  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
-    if [ ! -e $keystorePath ]; then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
-      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  # Key Store
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ]; then
+    if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+      keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+      if [ ! -e $keystorePath ]; then
+        # Generate the keystore.xml
+        export KEYSTOREPWD=$(openssl rand -base64 32)
+        sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+        chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      fi
     fi
   fi
 

--- a/releases/latest/full/helpers/runtime/docker-server.sh
+++ b/releases/latest/full/helpers/runtime/docker-server.sh
@@ -21,8 +21,9 @@ function importKeyCert() {
   local KEYSTORE_FILE="/output/resources/security/key.p12"
   local TRUSTSTORE_FILE="/output/resources/security/trust.p12"
 
+  
   # Import the private key and certificate into new keystore
-  if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
@@ -47,7 +48,7 @@ function importKeyCert() {
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
     
     # Add mounted CA to the truststore
-    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+    if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
         echo "Found mounted TLS CA certificate, adding to truststore"
         keytool -import -storetype pkcs12 -noprompt -keystore "${TRUSTSTORE_FILE}" -file "${CERT_FOLDER}/${CA_FILE}" \
           -storepass "${TRUSTSTORE_PASSWORD}" -alias "service-ca" >&/dev/null    
@@ -56,7 +57,7 @@ function importKeyCert() {
 
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
-  if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
     mkdir /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
@@ -71,15 +72,17 @@ function importKeyCert() {
   fi
 
   # Add the keystore password to server configuration
-  if [ ! -e $keystorePath ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ ! -e $keystorePath ]; then
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
-  if [ -e $TRUSTSTORE_FILE ]; then
-    setPasswords PASSWORD TRUSTSTORE_PASSWORD
-    sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
-  elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
-    cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ]; then
+    if [ -e $TRUSTSTORE_FILE ]; then
+      setPasswords PASSWORD TRUSTSTORE_PASSWORD
+      sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
+    elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
+      cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+    fi
   fi
 }
 
@@ -128,18 +131,5 @@ fi
 
 
 # Pass on to the real server run
-if [ -d "/output/workarea/checkpoint/image" ]; then
-  # A checkpoint image found; exec dumb-init for signal handling.
-  # Use of dumb-init for PID 1 is required for signal handling because
-  # the restored server process cannot be PID 1.
-  exec dumb-init --rewrite 15:2 -- /opt/ol/helpers/runtime/restore-server.sh "$@"
-elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
-  # Unset WLP_CHECKPOINT so it is not set in the final image after checkpoint.
-  TMP_CHECKPOINT=$WLP_CHECKPOINT
-  unset WLP_CHECKPOINT
-  # A checkpoint action has been requested; run the checkpoint.sh script.
-  checkpoint.sh "$TMP_CHECKPOINT"
-else
-  # The default is to just exec the supplied CMD
-  exec "$@"
-fi
+exec "$@"
+

--- a/releases/latest/kernel-slim/helpers/build/configure.sh
+++ b/releases/latest/kernel-slim/helpers/build/configure.sh
@@ -34,13 +34,15 @@ function main() {
   fi
 
   # Key Store
-  keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
-  if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
-    if [ ! -e $keystorePath ]; then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
-      chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ]; then
+    if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
+      keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+      if [ ! -e $keystorePath ]; then
+        # Generate the keystore.xml
+        export KEYSTOREPWD=$(openssl rand -base64 32)
+        sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+        chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      fi
     fi
   fi
 

--- a/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
@@ -21,8 +21,9 @@ function importKeyCert() {
   local KEYSTORE_FILE="/output/resources/security/key.p12"
   local TRUSTSTORE_FILE="/output/resources/security/trust.p12"
 
+  
   # Import the private key and certificate into new keystore
-  if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
@@ -47,7 +48,7 @@ function importKeyCert() {
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
     
     # Add mounted CA to the truststore
-    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+    if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
         echo "Found mounted TLS CA certificate, adding to truststore"
         keytool -import -storetype pkcs12 -noprompt -keystore "${TRUSTSTORE_FILE}" -file "${CERT_FOLDER}/${CA_FILE}" \
           -storepass "${TRUSTSTORE_PASSWORD}" -alias "service-ca" >&/dev/null    
@@ -56,7 +57,7 @@ function importKeyCert() {
 
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
-  if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ] && [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
     mkdir /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
@@ -71,15 +72,17 @@ function importKeyCert() {
   fi
 
   # Add the keystore password to server configuration
-  if [ ! -e $keystorePath ]; then
+  if [ "$EXCLUDE_CONFIG_KEYSTORE" != "false" ] && [ ! -e $keystorePath ]; then
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
-  if [ -e $TRUSTSTORE_FILE ]; then
-    setPasswords PASSWORD TRUSTSTORE_PASSWORD
-    sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
-  elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
-    cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+  if [ "$EXCLUDE_CONFIG_TRUSTSTORE" != "false" ]; then
+    if [ -e $TRUSTSTORE_FILE ]; then
+      setPasswords PASSWORD TRUSTSTORE_PASSWORD
+      sed "s|PWD_TRUST|$TRUSTSTORE_PASSWORD|g" $SNIPPETS_SOURCE/truststore.xml > $SNIPPETS_TARGET_OVERRIDES/truststore.xml
+    elif [ ! -z $SEC_TLS_TRUSTDEFAULTCERTS ]; then
+      cp $SNIPPETS_SOURCE/trustDefault.xml $SNIPPETS_TARGET_OVERRIDES/trustDefault.xml  
+    fi
   fi
 }
 
@@ -128,18 +131,5 @@ fi
 
 
 # Pass on to the real server run
-if [ -d "/output/workarea/checkpoint/image" ]; then
-  # A checkpoint image found; exec dumb-init for signal handling.
-  # Use of dumb-init for PID 1 is required for signal handling because
-  # the restored server process cannot be PID 1.
-  exec dumb-init --rewrite 15:2 -- /opt/ol/helpers/runtime/restore-server.sh "$@"
-elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
-  # Unset WLP_CHECKPOINT so it is not set in the final image after checkpoint.
-  TMP_CHECKPOINT=$WLP_CHECKPOINT
-  unset WLP_CHECKPOINT
-  # A checkpoint action has been requested; run the checkpoint.sh script.
-  checkpoint.sh "$TMP_CHECKPOINT"
-else
-  # The default is to just exec the supplied CMD
-  exec "$@"
-fi
+exec "$@"
+


### PR DESCRIPTION
Fixes #398
- Adds `EXCLUDE_CONFIG_KEYSTORE` to prevent generating the default keystore
- Adds `EXCLUDE_CONFIG_TRUSTSTORE` to prevent generating the default truststore/adding the keystore to the default truststore. 