### PR TITLE
Update to UBI 9 (23.0.0.10+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo apt-get update
 env:
   - RELEASE=../releases/23.0.0.6
+  - RELEASE=../releases/23.0.0.9
   - RELEASE=../releases/23.0.0.10
   - RELEASE=../releases/latest
 

--- a/releases/23.0.0.10/full/Dockerfile.ubi.ibmjava8
+++ b/releases/23.0.0.10/full/Dockerfile.ubi.ibmjava8
@@ -1,4 +1,4 @@
-FROM ibmjava:8-ubi AS getRuntime
+FROM ibmjava:8-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM ibmjava:8-ubi
+FROM ibmjava:8-ubi9
 
 USER root
 

--- a/releases/23.0.0.10/full/Dockerfile.ubi.openjdk11
+++ b/releases/23.0.0.10/full/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9
 
 USER root
 

--- a/releases/23.0.0.10/full/Dockerfile.ubi.openjdk17
+++ b/releases/23.0.0.10/full/Dockerfile.ubi.openjdk17
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9
 
 USER root
 

--- a/releases/23.0.0.10/full/Dockerfile.ubi.openjdk8
+++ b/releases/23.0.0.10/full/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9
 
 USER root
 

--- a/releases/23.0.0.10/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/23.0.0.10/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -1,4 +1,4 @@
-FROM ibmjava:8-ubi AS getRuntime
+FROM ibmjava:8-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM ibmjava:8-ubi
+FROM ibmjava:8-ubi9
 
 USER root
 

--- a/releases/23.0.0.10/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/23.0.0.10/kernel-slim/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9
 
 USER root
 

--- a/releases/23.0.0.10/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/23.0.0.10/kernel-slim/Dockerfile.ubi.openjdk17
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9
 
 USER root
 

--- a/releases/23.0.0.10/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/23.0.0.10/kernel-slim/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9
 
 USER root
 

--- a/releases/latest/beta/Dockerfile.ubi.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubi.openjdk17
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9
 
 USER root
 

--- a/releases/latest/full/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/full/Dockerfile.ubi.ibmjava8
@@ -1,4 +1,4 @@
-FROM ibmjava:8-ubi AS getRuntime
+FROM ibmjava:8-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM ibmjava:8-ubi
+FROM ibmjava:8-ubi9
 
 USER root
 

--- a/releases/latest/full/Dockerfile.ubi.openjdk11
+++ b/releases/latest/full/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9
 
 USER root
 

--- a/releases/latest/full/Dockerfile.ubi.openjdk17
+++ b/releases/latest/full/Dockerfile.ubi.openjdk17
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9
 
 USER root
 

--- a/releases/latest/full/Dockerfile.ubi.openjdk8
+++ b/releases/latest/full/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9
 
 USER root
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -1,4 +1,4 @@
-FROM ibmjava:8-ubi AS getRuntime
+FROM ibmjava:8-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM ibmjava:8-ubi
+FROM ibmjava:8-ubi9
 
 USER root
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9
 
 USER root
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9
 
 USER root
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -24,7 +24,7 @@ RUN yum -y install shadow-utils wget unzip openssl \
     && chown -R 1001:0 /opt/ol/wlp \
     && chmod -R g+rw /opt/ol/wlp
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9
 
 USER root
 


### PR DESCRIPTION
- Use Semeru images based on UBI 9 the base image for Liberty 23.0.0.10+
- Update the tag of IBM Java base image to use UBI 9. We need to make the corresponding changes to [build.sh in build-liberty-images-ubi repo ](https://github.ibm.com/was-docker/build-liberty-images-ubi/blob/bc368ae90cd92f0b0186976b597c9936abde3728/build.sh#L58) to create this new base image
- Update travis yaml to specify the right set of versions. This is unused I think, but just in case it's referenced/used