### PR TITLE
Use instanton.ld.so.cache for checkpointing java

### DIFF
--- a/releases/latest/beta/Dockerfile.ubi.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubi.openjdk17
@@ -132,6 +132,7 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
+    && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 # Create a new SCC layer

--- a/releases/latest/beta/helpers/build/checkpoint.sh
+++ b/releases/latest/beta/helpers/build/checkpoint.sh
@@ -6,6 +6,10 @@ do
     pidplus.sh
 done
 
+if [ -e /etc/instanton.ld.so.cache ]; then
+    cp /etc/instanton.ld.so.cache /etc/ld.so.cache
+fi
+
 echo "Performing checkpoint --at=$1"
 /opt/ol/wlp/bin/server checkpoint defaultServer --at=$1
 

--- a/releases/latest/full/Dockerfile.ubi.openjdk17
+++ b/releases/latest/full/Dockerfile.ubi.openjdk17
@@ -132,6 +132,7 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
+    && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 # Create a new SCC layer

--- a/releases/latest/full/helpers/build/checkpoint.sh
+++ b/releases/latest/full/helpers/build/checkpoint.sh
@@ -6,6 +6,10 @@ do
     pidplus.sh
 done
 
+if [ -e /etc/instanton.ld.so.cache ]; then
+    cp /etc/instanton.ld.so.cache /etc/ld.so.cache
+fi
+
 echo "Performing checkpoint --at=$1"
 /opt/ol/wlp/bin/server checkpoint defaultServer --at=$1
 

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
@@ -130,6 +130,7 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
+    && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
 
 # Create a new SCC layer

--- a/releases/latest/kernel-slim/helpers/build/checkpoint.sh
+++ b/releases/latest/kernel-slim/helpers/build/checkpoint.sh
@@ -6,6 +6,10 @@ do
     pidplus.sh
 done
 
+if [ -e /etc/instanton.ld.so.cache ]; then
+    cp /etc/instanton.ld.so.cache /etc/ld.so.cache
+fi
+
 echo "Performing checkpoint --at=$1"
 /opt/ol/wlp/bin/server checkpoint defaultServer --at=$1
 


### PR DESCRIPTION
Semeru images may contain a custom InstantOn ld.so.cache that improves the portability of checkpointed Java programs. Use it by overwriting ld.so.cache with instanton.ld.so.cache before starting the process being checkpointed.

Note that in order to overwrite ld.so.cache at checkpoint time we have to give the checkpoint user write permission to the file; this is done by making the file group-writable.