### PR TITLE
docker-server.sh put keystore config into overrides instead of default

### DIFF
--- a/releases/latest/beta/helpers/runtime/docker-server.sh
+++ b/releases/latest/beta/helpers/runtime/docker-server.sh
@@ -23,6 +23,9 @@ function importKeyCert() {
 
   # Import the private key and certificate into new keystore
   if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
+  # ILC - at this point, we have found mounted certificates. We are going to
+  #  1. create a new keystore (this will overwrite an existing one
+  #  2. put the liberty keystore config into an override snippet
     echo "Found mounted TLS certificates, generating keystore"
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
     mkdir -p /output/resources/security
@@ -44,7 +47,15 @@ function importKeyCert() {
     fi
 
     # Since we are creating new keystore, always write new password to a file
-    sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+    # ILC this is now going to overrides
+    sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $keystorePathOverride
+    # If configure.sh has been run, then there will be a keystore.xml in configDropins/defaults
+    # This will cause a conflict and a warning on server startup, so we should try to delete it
+    echo "Attempting to remove a previous keystore.xml"
+    if [ -e "$keystorePathDefault" ];
+    then
+        rm "$keystorePathDefault"
+    fi
     
     # Add mounted CA to the truststore
     if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
@@ -71,9 +82,21 @@ function importKeyCert() {
   fi
 
   # Add the keystore password to server configuration
-  if [ ! -e $keystorePath ]; then
+  # ILC - this is checking if keystore.xml exists in defaults, and creating it if it doesn't
+  # This doesn't actually create a keystore, and it would be overriden by something in server.xml
+  # and it would be overriden by the stuff in overrides.
+  # so this shouldn't interfere with any customer config.
+  # the main effect would seem to be that the password ends up in keystore.xml
+  # rather than in server.env, if liberty creates everything on startup
+  # where does configure.sh put the password if it creates it?
+  # configure.sh creates a password and puts it in keystore.xml
+  # but configure.sh may not have been run
+  # so we probably need want to keep this but gate it on differently on the above
+  # creation of an override
+  
+  if [ ! -e "$keystorePathDefault" ] && [ ! -e "$keystorePathOverride" ]; then
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
-    sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+    sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $keystorePathDefault
   fi
   if [ -e $TRUSTSTORE_FILE ]; then
     setPasswords PASSWORD TRUSTSTORE_PASSWORD
@@ -89,7 +112,8 @@ SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
 SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
 SNIPPETS_TARGET_OVERRIDES=/config/configDropins/overrides
 
-keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+keystorePathDefault="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
+keystorePathOverride="$SNIPPETS_TARGET_OVERRIDES/keystore.xml"
 
 if [ "$SSL" = "true" ] || [ "$TLS" = "true" ]; then
   cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET_OVERRIDES/tls.xml

--- a/releases/latest/full/helpers/runtime/docker-server.sh
+++ b/releases/latest/full/helpers/runtime/docker-server.sh
@@ -49,6 +49,13 @@ function importKeyCert() {
     # Since we are creating new keystore, always write new password to a file
     # ILC this is now going to overrides
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $keystorePathOverride
+    # If configure.sh has been run, then there will be a keystore.xml in configDropins/defaults
+    # This will cause a conflict and a warning on server startup, so we should try to delete it
+    echo "Attempting to remove a previous keystore.xml"
+    if [ -e "$keystorePathDefault" ];
+    then
+        rm "$keystorePathDefault"
+    fi
     
     # Add mounted CA to the truststore
     if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then

--- a/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
@@ -49,6 +49,13 @@ function importKeyCert() {
     # Since we are creating new keystore, always write new password to a file
     # ILC this is now going to overrides
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $keystorePathOverride
+    # If configure.sh has been run, then there will be a keystore.xml in configDropins/defaults
+    # This will cause a conflict and a warning on server startup, so we should try to delete it
+    echo "Attempting to remove a previous keystore.xml"
+    if [ -e "$keystorePathDefault" ];
+    then
+        rm "$keystorePathDefault"
+    fi
     
     # Add mounted CA to the truststore
     if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then


### PR DESCRIPTION
First stab at addressing #427

If docker-server.sh finds certificates mounted in '/etc/x509/certs', we make the assumption that the user wants us to manage their certificates for them. This means that we are 'safe' to put our keystore config in configDropins/overrides. This will prevent the issue reported in 427, as the generated keystore/config will override the config from the example server.xml, so there will no longer be a mismatch between keystore and keystore password.

The openssl commands will overwrite an existing keystore in the default location, so creating the keystore will always suceed, even if an existing keystore is in the container image.

If the user has run configure.sh in their dockerfile, then there will be an existing keystore.xml snippet in configDropins/defaults. This will cause a warning at server startup due to multiple definitions of the keystore config. The override will win the conflict, so it would be safe to leave the defaults keystore.xml in place, but it is probably better to try and remove it.
Again, this should be safe, as it is highly unlikely that a user would have written to this specific file location and name.

A potentially 'fail' scenario would be if a user has added a keystore + config into their container image, and also mounted certificates in /etc/x509/certs. We would then overwrite their keystore, and override their keystore config.
This is an unlikely scenario as it is not best practice to put a keystore into a container image, and in addition, the user would then be unlikely to mount certificates into /etc/x509/certs.