### PR TITLE
 Enable GitHub Actions workflow to automate new release updates

### DIFF
--- a/.github/workflows/update_files_for_release.yml
+++ b/.github/workflows/update_files_for_release.yml
@@ -1,0 +1,66 @@
+# This workflow is triggered by manual inputs.
+
+name: Update files for the new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      OLD_VERSION:
+        description: 'Enter old version'
+        # Show defaults as examples so user enters correct format.
+        default: '23.0.0.11'
+        required: true
+        type: string
+      NEW_VERSION:
+        description: 'Enter new version'
+        default: '23.0.0.12'
+        required: true
+        type: string
+      BETA_VERSION:
+        description: 'Enter new version'
+        default: '23.0.0.13-beta'
+        type: string
+      BUILD_LABEL:
+        description: 'Enter build label of release driver'
+        default: 'replace_with_gm_driver_label'
+        required: false
+        type: string
+
+jobs:
+  automate_release_updates:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Show useful information about the workflow environment
+      run: echo "🔎 This workflow is running in branch ${{ github.ref }} and repository ${{ github.repository }}."
+
+    # This repository and branch to clone and checkout on runner 
+    # could be different than repo and branch where workflow runs.
+    # Be aware of this nuance.
+    - name: Check out repository code to runner
+      uses: actions/checkout@v4
+      with:
+        ref: vNext
+        repository: OpenLiberty/ci.docker
+
+    - name: Run update.sh script
+      run: bash ./update.sh ${{ inputs.OLD_VERSION }} ${{ inputs.NEW_VERSION }} ${{ inputs.BUILD_LABEL }}
+
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9
+      with: 
+        default_author: github_actions
+        author_name: GitHub Actions
+        message: "Updates for the release of ${{ inputs.NEW_VERSION }}"
+        add: '${{ github.workspace }}/ga/*'
+        new_branch: "${{ inputs.NEW_VERSION }}-release"
+        push: true
+        tag_push: '--force'
+
+    - name: Create Pull Request
+      run: |
+        gh pr create -B vNext -H "${{ inputs.NEW_VERSION }}-release" -r mbroz2 -r leochr --title "Updates for the release of ${{ inputs.NEW_VERSION }}" --body "Created by Github Actions"
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/update_files_for_release.yml
+++ b/.github/workflows/update_files_for_release.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: vNext
-        repository: wraschke/ci.docker-1
+        repository: OpenLiberty/ci.docker
 
     - name: Run update.sh script
       run: bash ./update.sh ${{ inputs.OLD_VERSION }} ${{ inputs.NEW_VERSION }} ${{ inputs.BETA_VERSION }} ${{ inputs.BUILD_LABEL }}

--- a/.github/workflows/update_files_for_release.yml
+++ b/.github/workflows/update_files_for_release.yml
@@ -17,8 +17,9 @@ on:
         required: true
         type: string
       BETA_VERSION:
-        description: 'Enter new version'
-        default: '23.0.0.13-beta'
+        description: 'Enter beta version'
+        default: '24.0.0.1'
+        required: true
         type: string
       BUILD_LABEL:
         description: 'Enter build label of release driver'
@@ -41,10 +42,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: vNext
-        repository: OpenLiberty/ci.docker
+        repository: wraschke/ci.docker-1
 
     - name: Run update.sh script
-      run: bash ./update.sh ${{ inputs.OLD_VERSION }} ${{ inputs.NEW_VERSION }} ${{ inputs.BUILD_LABEL }}
+      run: bash ./update.sh ${{ inputs.OLD_VERSION }} ${{ inputs.NEW_VERSION }} ${{ inputs.BETA_VERSION }} ${{ inputs.BUILD_LABEL }}
 
     - name: Commit changes
       uses: EndBug/add-and-commit@v9
@@ -52,7 +53,7 @@ jobs:
         default_author: github_actions
         author_name: GitHub Actions
         message: "Updates for the release of ${{ inputs.NEW_VERSION }}"
-        add: '${{ github.workspace }}/ga/*'
+        add: '${{ github.workspace }}/releases/* ${{ github.workspace }}/.travis.yml'
         new_branch: "${{ inputs.NEW_VERSION }}-release"
         push: true
         tag_push: '--force'


### PR DESCRIPTION
This pull request's objective is to fully automate the vNext updates in ci.docker repos for an upcoming release.

This test workflow done in my fork demos what this code should do: https://github.com/wraschke/ci.docker-1/actions/runs/6698088966/job/18199389168

Resulting pull request created by automation: https://github.com/wraschke/ci.docker-1/pull/9

It's not possible to test this file as it would really behave in the OpenLiberty/ci.docker repo until I merge this PR. 

And note that this PR introduces only the workflow YML file into main. The script it invokes needs to live in vNext: see https://github.com/OpenLiberty/ci.docker/pull/476.

