### PR TITLE
GitHub Action release updates automation fixes

### DIFF
--- a/.github/workflows/update_files_for_release.yml
+++ b/.github/workflows/update_files_for_release.yml
@@ -44,8 +44,8 @@ jobs:
         ref: vNext
         repository: OpenLiberty/ci.docker
 
-    - name: Run update.sh script
-      run: bash ./update.sh ${{ inputs.OLD_VERSION }} ${{ inputs.NEW_VERSION }} ${{ inputs.BETA_VERSION }} ${{ inputs.BUILD_LABEL }}
+    - name: Run create-new-release.sh script
+      run: bash ./create-new-release.sh ${{ inputs.OLD_VERSION }} ${{ inputs.NEW_VERSION }} ${{ inputs.BETA_VERSION }} ${{ inputs.BUILD_LABEL }}
 
     - name: Commit changes
       uses: EndBug/add-and-commit@v9

--- a/.github/workflows/update_files_for_release.yml
+++ b/.github/workflows/update_files_for_release.yml
@@ -23,7 +23,7 @@ on:
         type: string
       BUILD_LABEL:
         description: 'Enter build label of release driver'
-        default: 'replace_with_gm_driver_label'
+        default: '{replace_with_gm_driver_label}'
         required: false
         type: string
 

--- a/create-new-release.sh
+++ b/create-new-release.sh
@@ -29,6 +29,9 @@ echo "OLD_SHORT_VERSION = $OLD_SHORT_VERSION"
 
 echo "Copying latest files to $NEW_VERSION"
 cp -r ./releases/latest ./releases/$NEW_VERSION
+# Remove the beta subdir from the new release directory.
+# There is probably a more efficient way to exclude during a copy.
+rm -r ./releases/$NEW_VERSION/beta
 
 # Perform the substitutions in both latest and $NEW_VERSION directories.
 for file in $(find ./releases/latest ./releases/$NEW_VERSION -name Dockerfile.*); do

--- a/create-new-release.sh
+++ b/create-new-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Hello from the update.sh script!"
+echo "Hello from the create-new-release.sh script!"
 echo $(date)
 
 # Set variables to the positional parameters


### PR DESCRIPTION
This addresses comment Leo made at https://github.com/OpenLiberty/ci.docker/pull/485#discussion_r1394475255 about not copying "beta" subdirectory and also https://github.com/OpenLiberty/ci.docker/pull/485#discussion_r1394476999, which does not affect functionality. It just makes placeholder text for build label consistent with the SHA value placeholder text.