### PR TITLE
Specify the correct features SHA for 24.0.0.2

### DIFF
--- a/releases/24.0.0.2/full/Dockerfile.ubi.openjdk21
+++ b/releases/24.0.0.2/full/Dockerfile.ubi.openjdk21
@@ -4,7 +4,7 @@ FROM $PARENT_IMAGE AS installBundle
 
 ARG VERBOSE=false
 ARG LIBERTY_VERSION=24.0.0.2
-ARG FEATURES_SHA=6475edcd283f2f564706f23679d830af83c4dfaf
+ARG FEATURES_SHA=4da875dfbd1850f1ec369ba896b7022fe20498a6
 
 # If there is a local copy of the repository use that instead
 COPY resources/ /tmp/

--- a/releases/latest/full/Dockerfile.ubi.openjdk21
+++ b/releases/latest/full/Dockerfile.ubi.openjdk21
@@ -4,7 +4,7 @@ FROM $PARENT_IMAGE AS installBundle
 
 ARG VERBOSE=false
 ARG LIBERTY_VERSION=24.0.0.2
-ARG FEATURES_SHA=6475edcd283f2f564706f23679d830af83c4dfaf
+ARG FEATURES_SHA=4da875dfbd1850f1ec369ba896b7022fe20498a6
 
 # If there is a local copy of the repository use that instead
 COPY resources/ /tmp/


### PR DESCRIPTION
Use the SHA from https://repo1.maven.org/maven2/io/openliberty/features/features/24.0.0.2/features-24.0.0.2.json.sha1

Prior to the GA of Liberty release, the SHA value of the features Maven zip (from the internal repo) is used, but after GA, the SHA value of features json (from maven repo) should be used
