### PR TITLE
Hide keystore logs

### DIFF
--- a/releases/latest/beta/helpers/build/configure.sh
+++ b/releases/latest/beta/helpers/build/configure.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-if [ "$VERBOSE" != "true" ]; then
-  exec >/dev/null
-fi
+. /opt/ol/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 
@@ -79,8 +77,10 @@ function main() {
   if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
     if [ ! -e $keystorePath ]; then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
+      hideLogs
+      KEYSTOREPWD=$(openssl rand -base64 32)
       sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      showLogs
       chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
     fi
   fi

--- a/releases/latest/beta/helpers/build/infinispan-client-setup.sh
+++ b/releases/latest/beta/helpers/build/infinispan-client-setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-if [ "$VERBOSE" != "true" ]; then
-  exec >/dev/null
-fi
+. /opt/ol/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 

--- a/releases/latest/beta/helpers/build/internal/logger.sh
+++ b/releases/latest/beta/helpers/build/internal/logger.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+function main() {
+    if [ "$VERBOSE" != "true" ]; then
+        exec >/dev/null
+    fi
+}
+
+function hideLogs() {
+    exec 3>&1 >/dev/null 4>&2 2>/dev/null
+}
+
+function showLogs() {
+    exec 1>&3 3>&- 2>&4 4>&-
+}
+
+main

--- a/releases/latest/beta/helpers/build/populate_scc.sh
+++ b/releases/latest/beta/helpers/build/populate_scc.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-if [ "$VERBOSE" != "true" ]; then
-  exec >/dev/null
-fi
+. /opt/ol/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 

--- a/releases/latest/full/helpers/build/configure.sh
+++ b/releases/latest/full/helpers/build/configure.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-if [ "$VERBOSE" != "true" ]; then
-  exec >/dev/null
-fi
+. /opt/ol/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 
@@ -79,8 +77,10 @@ function main() {
   if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
     if [ ! -e $keystorePath ]; then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
+      hideLogs
+      KEYSTOREPWD=$(openssl rand -base64 32)
       sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      showLogs
       chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
     fi
   fi

--- a/releases/latest/full/helpers/build/infinispan-client-setup.sh
+++ b/releases/latest/full/helpers/build/infinispan-client-setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-if [ "$VERBOSE" != "true" ]; then
-  exec >/dev/null
-fi
+. /opt/ol/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 

--- a/releases/latest/full/helpers/build/internal/logger.sh
+++ b/releases/latest/full/helpers/build/internal/logger.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+function main() {
+    if [ "$VERBOSE" != "true" ]; then
+        exec >/dev/null
+    fi
+}
+
+function hideLogs() {
+    exec 3>&1 >/dev/null 4>&2 2>/dev/null
+}
+
+function showLogs() {
+    exec 1>&3 3>&- 2>&4 4>&-
+}
+
+main

--- a/releases/latest/full/helpers/build/populate_scc.sh
+++ b/releases/latest/full/helpers/build/populate_scc.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-if [ "$VERBOSE" != "true" ]; then
-  exec >/dev/null
-fi
+. /opt/ol/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 

--- a/releases/latest/kernel-slim/helpers/build/configure.sh
+++ b/releases/latest/kernel-slim/helpers/build/configure.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-if [ "$VERBOSE" != "true" ]; then
-  exec >/dev/null
-fi
+. /opt/ol/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 
@@ -38,8 +36,10 @@ function main() {
   if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]; then
     if [ ! -e $keystorePath ]; then
       # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
+      hideLogs
+      KEYSTOREPWD=$(openssl rand -base64 32)
       sed "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml >$SNIPPETS_TARGET_DEFAULTS/keystore.xml
+      showLogs
       chmod g+w $SNIPPETS_TARGET_DEFAULTS/keystore.xml
     fi
   fi

--- a/releases/latest/kernel-slim/helpers/build/features.sh
+++ b/releases/latest/kernel-slim/helpers/build/features.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-if [ "$VERBOSE" != "true" ]; then
-  exec >/dev/null
-fi
+. /opt/ol/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 

--- a/releases/latest/kernel-slim/helpers/build/infinispan-client-setup.sh
+++ b/releases/latest/kernel-slim/helpers/build/infinispan-client-setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-if [ "$VERBOSE" != "true" ]; then
-  exec >/dev/null
-fi
+. /opt/ol/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 

--- a/releases/latest/kernel-slim/helpers/build/internal/logger.sh
+++ b/releases/latest/kernel-slim/helpers/build/internal/logger.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+function main() {
+    if [ "$VERBOSE" != "true" ]; then
+        exec >/dev/null
+    fi
+}
+
+function hideLogs() {
+    exec 3>&1 >/dev/null 4>&2 2>/dev/null
+}
+
+function showLogs() {
+    exec 1>&3 3>&- 2>&4 4>&-
+}
+
+main

--- a/releases/latest/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel-slim/helpers/build/populate_scc.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-if [ "$VERBOSE" != "true" ]; then
-  exec >/dev/null
-fi
+. /opt/ol/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 


### PR DESCRIPTION
The `configure.sh` script commands are being output to stderr by default. This change hides both stdout and stderr streams when generating the keystore and imports the `logger.sh` script to set the `VERBOSE` flag. It can be used to suppress additional noise from output in the future. 