### PR TITLE
Show console.log if server fails when building SCC

### DIFF
--- a/releases/24.0.0.6/full/helpers/build/populate_scc.sh
+++ b/releases/24.0.0.6/full/helpers/build/populate_scc.sh
@@ -110,7 +110,7 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then
@@ -145,7 +145,7 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then

--- a/releases/24.0.0.6/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/24.0.0.6/kernel-slim/helpers/build/populate_scc.sh
@@ -110,7 +110,7 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then
@@ -145,7 +145,7 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then

--- a/releases/24.0.0.9/full/helpers/build/populate_scc.sh
+++ b/releases/24.0.0.9/full/helpers/build/populate_scc.sh
@@ -110,7 +110,7 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then
@@ -145,7 +145,7 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then

--- a/releases/24.0.0.9/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/24.0.0.9/kernel-slim/helpers/build/populate_scc.sh
@@ -110,7 +110,7 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then
@@ -145,7 +145,7 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then

--- a/releases/latest/beta/helpers/build/populate_scc.sh
+++ b/releases/latest/beta/helpers/build/populate_scc.sh
@@ -110,7 +110,7 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then
@@ -145,7 +145,7 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then

--- a/releases/latest/full/helpers/build/populate_scc.sh
+++ b/releases/latest/full/helpers/build/populate_scc.sh
@@ -110,7 +110,7 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then
@@ -145,7 +145,7 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then

--- a/releases/latest/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel-slim/helpers/build/populate_scc.sh
@@ -110,7 +110,7 @@ if [ $TRIM_SCC == yes ]
 then
   echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
   # Populate the newly created class cache layer.
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then
@@ -145,7 +145,7 @@ fi
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster.
 for ((i=0; i<$ITERATIONS; i++))
 do
-  /opt/ol/wlp/bin/server start
+  /opt/ol/wlp/bin/server start || { rc=$?; cat /logs/console.log; exit $rc; }
 
   if [ ${WARM_ENDPOINT} == true ]
   then


### PR DESCRIPTION
Show the console.log if the `server start` commands in populate_scc.sh fail, otherwise any useful error messages are going to probably be lost.