### PR TITLE
Add runtime support for writing /logs to a /serviceability directory

### DIFF
--- a/releases/latest/beta/Dockerfile.ubi.openjdk21
+++ b/releases/latest/beta/Dockerfile.ubi.openjdk21
@@ -108,8 +108,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -122,8 +121,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -136,7 +133,21 @@ RUN mkdir /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
     && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk11
@@ -85,8 +85,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -99,8 +98,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -112,7 +109,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml   
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk17
@@ -85,8 +85,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -99,8 +98,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -112,7 +109,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml   
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk8
@@ -85,8 +85,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -99,8 +98,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -112,7 +109,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml   
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/beta/helpers/runtime/docker-server.sh
+++ b/releases/latest/beta/helpers/runtime/docker-server.sh
@@ -141,5 +141,11 @@ elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
   checkpoint.sh "$TMP_CHECKPOINT"
 else
   # The default is to just exec the supplied CMD
+  if [[ ! -z "$SERVICEABILITY_NAMESPACE" ]] && [[ ! -z $HOSTNAME ]]; then
+    SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME"
+    mkdir -p $SERVICEABILITY_FOLDER
+    rm -f /opt/ol/links/logs
+    ln -s $SERVICEABILITY_FOLDER /opt/ol/links/logs
+  fi
   exec "$@"
 fi

--- a/releases/latest/full/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/full/Dockerfile.ubi.ibmjava8
@@ -107,8 +107,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -121,8 +120,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -134,7 +131,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/full/Dockerfile.ubi.openjdk11
+++ b/releases/latest/full/Dockerfile.ubi.openjdk11
@@ -107,8 +107,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -121,8 +120,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -135,7 +132,21 @@ RUN mkdir /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
     && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/full/Dockerfile.ubi.openjdk17
+++ b/releases/latest/full/Dockerfile.ubi.openjdk17
@@ -107,8 +107,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -121,8 +120,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -135,7 +132,21 @@ RUN mkdir /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
     && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/full/Dockerfile.ubi.openjdk8
+++ b/releases/latest/full/Dockerfile.ubi.openjdk8
@@ -107,8 +107,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -121,8 +120,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -135,7 +132,21 @@ RUN mkdir /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
     && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk11
@@ -85,8 +85,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -99,8 +98,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -112,7 +109,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk17
@@ -85,8 +85,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -99,8 +98,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -112,7 +109,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk8
@@ -85,8 +85,7 @@ RUN /opt/ol/wlp/bin/server create --template=javaee8 \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -99,8 +98,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -112,7 +109,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/full/helpers/runtime/docker-server.sh
+++ b/releases/latest/full/helpers/runtime/docker-server.sh
@@ -141,5 +141,11 @@ elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
   checkpoint.sh "$TMP_CHECKPOINT"
 else
   # The default is to just exec the supplied CMD
+  if [[ ! -z "$SERVICEABILITY_NAMESPACE" ]] && [[ ! -z $HOSTNAME ]]; then
+    SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME"
+    mkdir -p $SERVICEABILITY_FOLDER
+    rm -f /opt/ol/links/logs
+    ln -s $SERVICEABILITY_FOLDER /opt/ol/links/logs
+  fi
   exec "$@"
 fi

--- a/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -107,8 +107,7 @@ RUN /opt/ol/wlp/bin/server create \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -119,8 +118,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -132,7 +129,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
@@ -107,8 +107,7 @@ RUN /opt/ol/wlp/bin/server create \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -119,8 +118,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -132,8 +129,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
@@ -107,8 +107,7 @@ RUN /opt/ol/wlp/bin/server create \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -119,8 +118,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -132,8 +129,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk21
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk21
@@ -108,8 +108,7 @@ RUN /opt/ol/wlp/bin/server create \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -121,8 +120,6 @@ RUN mkdir /logs \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -134,7 +131,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi
+    && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
@@ -108,7 +108,6 @@ RUN /opt/ol/wlp/bin/server create \
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
-    && mkdir -p /serviceability/logs \
     && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
@@ -139,10 +138,10 @@ RUN mkdir /logs \
     && chmod -R g+rw /opt/ol/links
 
 USER 1001
-RUN ln -s /serviceability/logs /opt/ol/links/logs
+RUN mkdir -p /serviceability/logs \
+    && ln -s /serviceability/logs /opt/ol/links/logs
 USER root
-RUN ln -s /opt/ol/links/logs /logs \
-    && chown -R 1001:0 /opt/ol/links/logs
+RUN ln -s /logs /opt/ol/links/logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
@@ -108,6 +108,7 @@ RUN /opt/ol/wlp/bin/server create \
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
+    && mkdir -p /serviceability/logs \
     && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
@@ -132,8 +133,16 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && if [ -e /etc/instanton.ld.so.cache ]; then chmod g+w /etc/ld.so.cache; fi \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links
+
+USER 1001
+RUN ln -s /serviceability/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs \
+    && chown -R 1001:0 /opt/ol/links/logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
@@ -107,8 +107,7 @@ RUN /opt/ol/wlp/bin/server create \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -119,8 +118,6 @@ RUN mkdir /logs \
     && ln -s /opt/ol/fixes /fixes \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs \
     && chown -R 1001:0 /opt/ol/wlp/usr \
     && chmod -R g+rw /opt/ol/wlp/usr \
     && chown -R 1001:0 /opt/ol/wlp/output \
@@ -141,7 +138,9 @@ USER 1001
 RUN mkdir -p /serviceability/logs \
     && ln -s /serviceability/logs /opt/ol/links/logs
 USER root
-RUN ln -s /logs /opt/ol/links/logs
+RUN ln -s /logs /opt/ol/links/logs \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
@@ -132,15 +132,18 @@ RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && mkdir -p /opt/ol/links \
     && chown -R 1001:0 /opt/ol/links \
-    && chmod -R g+rw /opt/ol/links
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
 
 USER 1001
-RUN mkdir -p /serviceability/logs \
-    && ln -s /serviceability/logs /opt/ol/links/logs
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
 USER root
-RUN ln -s /logs /opt/ol/links/logs \
-    && chown -R 1001:0 /logs \
-    && chmod -R g+rw /logs
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -85,8 +85,7 @@ RUN /opt/ol/wlp/bin/server create \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -110,7 +109,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -85,8 +85,7 @@ RUN /opt/ol/wlp/bin/server create \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -110,7 +109,21 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
+
+USER 1001
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -85,9 +85,7 @@ RUN /opt/ol/wlp/bin/server create \
     && rm -rf /opt/ol/wlp/usr/servers/defaultServer/server.env
 
 # Create symlinks && set permissions for non-root user
-RUN mkdir /logs \
-    && mkdir -p /serviceability/logs \
-    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+RUN mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
@@ -114,13 +112,18 @@ RUN mkdir /logs \
     && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
     && mkdir -p /opt/ol/links \
     && chown -R 1001:0 /opt/ol/links \
-    && chmod -R g+rw /opt/ol/links
+    && chmod -R g+rw /opt/ol/links \
+    && mkdir -p /opt/ol/logs \
+    && chown -R 1001:0 /opt/ol/logs \
+    && chmod -R g+rw /opt/ol/logs \
+    && mkdir -p /serviceability \
+    && chown -R 1001:0 /serviceability \
+    && chmod -R g+rw /serviceability
 
 USER 1001
-RUN ln -s /serviceability/logs /opt/ol/links/logs
+RUN ln -s /opt/ol/logs /opt/ol/links/logs
 USER root
-RUN ln -s /opt/ol/links/logs /logs \
-    && chown -R 1001:0 /opt/ol/links/logs
+RUN ln -s /opt/ol/links/logs /logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -86,6 +86,7 @@ RUN /opt/ol/wlp/bin/server create \
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
+    && mkdir -p /serviceability/logs \
     && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
     && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
@@ -110,7 +111,16 @@ RUN mkdir /logs \
     && mkdir /etc/wlp \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
+    && mkdir -p /opt/ol/links \
+    && chown -R 1001:0 /opt/ol/links \
+    && chmod -R g+rw /opt/ol/links
+
+USER 1001
+RUN ln -s /serviceability/logs /opt/ol/links/logs
+USER root
+RUN ln -s /opt/ol/links/logs /logs \
+    && chown -R 1001:0 /opt/ol/links/logs
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \

--- a/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
@@ -141,8 +141,8 @@ elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
   checkpoint.sh "$TMP_CHECKPOINT"
 else
   # The default is to just exec the supplied CMD
-  if [[ ! -z "$SERVICEABILITY_NAMESPACE" ]] && [[ ! -z $SERVICEABILITY_NAME ]]; then
-    SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$SERVICEABILITY_NAME"
+  if [[ ! -z "$SERVICEABILITY_NAMESPACE" ]] && [[ ! -z $HOSTNAME ]]; then
+    SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME"
     mkdir -p $SERVICEABILITY_FOLDER
     rm -f /opt/ol/links/logs
     ln -s $SERVICEABILITY_FOLDER /opt/ol/links/logs

--- a/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
@@ -141,5 +141,11 @@ elif [[ ! -z "$WLP_CHECKPOINT" ]]; then
   checkpoint.sh "$TMP_CHECKPOINT"
 else
   # The default is to just exec the supplied CMD
+  if [[ ! -z "$SERVICEABILITY_NAMESPACE" ]] && [[ ! -z $SERVICEABILITY_NAME ]]; then
+    SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$SERVICEABILITY_NAME"
+    mkdir -p $SERVICEABILITY_FOLDER
+    rm -f /opt/ol/links/logs
+    ln -s $SERVICEABILITY_FOLDER /opt/ol/links/logs
+  fi
   exec "$@"
 fi


### PR DESCRIPTION
- This change allows you to set env vars `SERVICEABILITY_NAMESPACE` and `HOSTNAME` to automatically create a directory `/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME` for redirecting Liberty log output into.