### PR TITLE
MP Health file-based health check scripts

### DIFF
--- a/releases/latest/beta/helpers/runtime/livenessHealthCheck.sh
+++ b/releases/latest/beta/helpers/runtime/livenessHealthCheck.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+#Default to Kubernetes default for periodSeconds of 10 seconds
+period_seconds=10
+period_milliseconds=$((period_seconds * 1000))
+
+#Default location for 'live' file - Can change through parameter or server env
+live_file=/output/health/live
+
+
+# Evaluate if there is a env var for periodSeconds
+if [ -n "${LIVENESS_PROBE_PERIOD_SECONDS}" ]
+then
+  #Check input is numerical only
+  if [[ ${LIVENESS_PROBE_PERIOD_SECONDS} =~ ^[0-9]+$ ]]
+  then
+    period_seconds=${LIVENESS_PROBE_PERIOD_SECONDS}
+    period_milliseconds=$((period_seconds * 1000))
+  else
+    echo "Expected only a numerical value for LIVENESS_PROBE_PERIOD_SECONDS environment variable, but recieved: $2. This value will not be read in."
+  fi
+fi
+
+# Evaluate if there is a env var for 'live' file location
+if [ -n "${LIVE_FILE_LOCATION}" ]
+then
+  live_file=${LIVE_FILE_LOCATION}
+fi
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -p|--period-seconds)
+      #Check input is numerical only
+      if [[ $2 =~ ^[0-9]+$ ]]
+      then
+        period_seconds=$2
+        period_milliseconds=$((period_seconds*1000))
+      else
+        echo "Expected only a numerical value for the -p/--period-seconds parameter, but recieved: $2. Defaulting to 1 second timeoutSeconds or environment variable defined value if valid."
+      fi
+      shift
+      shift
+      ;;
+    -f|--file)
+      live_file=$2
+      shift
+      shift
+      ;;
+	--help)
+	  printf "This script is used to query the 'live' health check file to determine if the container is live or not. The default location is '/output/health/live' but can be configured with the -f/--file option or with the environment variable 'LIVE_FILE_LOCATION' if the file exists in another location. This script will check whether the file has been updated or not within the last 'period seconds' (defaults is 10 seconds). This value can be configured with the -p/--period-seconds option or with the 'LIVENESS_PROBE_PERIOD_SECONDS' environment variable. It is important to configure the period seconds option for this script if the Kubernetes periodSeconds field of the liveness probe is configured. Failure to do so will result in misreporting of the liveness status of the container.\n\nNote that the options passed directly in to the script will supersede the environment variable configuration.\n\nUsage: ./livenessHealthCheck.sh <option>...\nOptions:\n\n\t-p/--period-seconds\n\t\t A numerical value that must match the periodSeconds field of the Kubernetes liveness probe configuration. The period seconds value is used by this script to determine if the container is live or not. Defaults is 1 (second).\n\n\t-f/--file\n\t\tThis value is used to inform the script of the location of the 'live' health-check file. The default is '/output/health/live'\n"
+	  exit 1
+	  ;;
+    *)
+     shift
+     ;;
+  esac
+done
+
+cat $live_file
+
+if [ $? -ne 0 ]
+then  
+  exit 1
+fi
+
+#What is the last modified time of the file
+modified_time=$(stat --format=%.3Y $live_file | tr -d ".") 
+
+
+if [ $(expr $(date +%s%3N) - $modified_time) -gt $period_milliseconds ]
+then
+  #File has not been updated within the last period_milliseconds; fail
+  exit 1
+else
+  #File has been updated within the last period_milliseconds; success!
+  exit 0
+fi

--- a/releases/latest/beta/helpers/runtime/readinessHealthCheck.sh
+++ b/releases/latest/beta/helpers/runtime/readinessHealthCheck.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+#Default to Kubernetes default for periodSeconds of 10 seconds
+period_seconds=10
+period_milliseconds=$((period_seconds * 1000))
+
+#Default location for 'ready' file - Can change through parameter or server env
+ready_file=/output/health/ready
+
+
+# Evaluate if there is a env var for periodSeconds
+if [ -n "${READINESS_PROBE_PERIOD_SECONDS}" ]
+then
+  #Check input is numerical only
+  if [[ ${READINESS_PROBE_PERIOD_SECONDS} =~ ^[0-9]+$ ]]
+  then
+    period_seconds=${READINESS_PROBE_PERIOD_SECONDS}
+    period_milliseconds=$((period_seconds * 1000))
+  else
+    echo "Expected only a numerical value for READINESS_PROBE_PERIOD_SECONDS environment variable, but recieved: $2. This value will not be read in."
+  fi
+fi
+
+# Evaluate if there is a env var for 'ready' file location
+if [ -n "${READY_FILE_LOCATION}" ]
+then
+  ready_file=${READY_FILE_LOCATION}
+fi
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -p|--period-seconds)
+      #Check input is numerical only
+      if [[ $2 =~ ^[0-9]+$ ]]
+      then
+        period_seconds=$2
+        period_milliseconds=$((period_seconds*1000))
+      else
+        echo "Expected only a numerical value for the -p/--period-seconds parameter, but recieved: $2. Defaulting to 1 second timeoutSeconds or environment variable defined value if valid."
+      fi
+      shift
+      shift
+      ;;
+    -f|--file)
+      ready_file=$2
+      shift
+      shift
+      ;;
+	--help)
+	  printf "This script is used to query the 'ready' health check file to determine if the container is ready or not. The default location is '/output/health/ready' but can be configured with the -f/--file option or with the environment variable 'READY_FILE_LOCATION' if the file exists in another location. This script will check whether the file has been updated or not within the last 'period seconds' (defaults is 10 seconds). This value can be configured with the -p/--period-seconds option or with the 'READINESS_PROBE_PERIOD_SECONDS' environment variable. It is important to configure the period seconds option for this script if the Kubernetes periodSeconds field of the readiness probe is configured. Failure to do so will result in misreporting of the readiness status of the container.\n\nNote that the options passed directly in to the script will supersede the environment variable configuration.\n\nUsage: ./readinessHealthCheck.sh <option>...\nOptions:\n\n\t-p/--period-seconds\n\t\t A numerical value that must match the periodSeconds field of the Kubernetes readiness probe configuration. The period seconds value is used by this script to determine if the container is ready or not. Defaults is 1 (second).\n\n\t-f/--file\n\t\tThis value is used to inform the script of the location of the 'ready' health-check file. The default is '/output/health/ready'\n"
+	  exit 1
+	  ;;
+    *)
+     shift
+     ;;
+  esac
+done
+
+cat $ready_file
+
+if [ $? -ne 0 ]
+then  
+  exit 1
+fi
+
+#What is the last modified time of the file
+modified_time=$(stat --format=%.3Y $ready_file | tr -d ".") 
+
+
+if [ $(expr $(date +%s%3N) - $modified_time) -gt $period_milliseconds ]
+then
+  #File has not been updated within the last period_milliseconds; fail
+  exit 1
+else
+  #File has been updated within the last period_milliseconds; success!
+  exit 0
+fi

--- a/releases/latest/beta/helpers/runtime/startupHealthCheck.sh
+++ b/releases/latest/beta/helpers/runtime/startupHealthCheck.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+#Default to 1s - Can change through parameter or server env
+timeout_seconds=1
+timeout_milliseconds=$((timeout_seconds * 1000))
+
+#Default location for 'started' file - Can change through parameter or server env
+started_file=/output/health/started
+
+#Static values - will not be changed
+sleep_seconds=0.01
+sleep_milliseconds=10
+
+
+# Evaluate if there is a env var for timeoutSeconds
+if [ -n "${STARTUP_PROBE_TIMEOUT_SECONDS}" ]
+then
+  #Check input is numerical only
+  if [[ ${STARTUP_PROBE_TIMEOUT_SECONDS} =~ ^[0-9]+$ ]]
+  then
+    timeout_seconds=${STARTUP_PROBE_TIMEOUT_SECONDS}
+    timeout_milliseconds=$((timeout_seconds * 1000))
+  else
+    echo "Expected only a numerical value for STARTUP_PROBE_TIMEOUT_SECONDS environment variable, but recieved: $2. This value will not be read in."
+  fi
+fi
+
+# Evaluate if there is a env var for 'started' file location
+if [ -n "${STARTED_FILE_LOCATION}" ]
+then
+  started_file=${STARTED_FILE_LOCATION}
+fi
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -t|--timeout-seconds)
+      #Check input is numerical only
+      if [[ $2 =~ ^[0-9]+$ ]]
+      then
+        timeout_seconds=$2
+        timeout_milliseconds=$((timeout_seconds*1000))
+      else
+        echo "Expected only a numerical value for the -t/--timeout-seconds parameter, but recieved: $2. Defaulting to 1 second timeoutSeconds or environment variable defined value if valid."
+      fi
+      shift
+      shift
+      ;;
+    -f|--file)
+      started_file=$2
+      shift
+      shift
+      ;;
+	--help)
+	  printf "This script is used to query the 'started' health check file to determine if the continaer is started. The default location is '/output/health/started' but can be configured with the -f/--file option or with the environment variable 'STARTED_FILE_LOCATION' if the file exists in another location. This script will check until the timeout duration has expired (default is 1 second) unless configured otherwise. It is important to configure the timeout option for this script if the Kubernetes timeoutSeconds field of the startup probe is configured. This can be achieved by using the -t/--timeout-seconds option or with the environment variable 'STARTUP_PROBE_TIMEOUT_SECONDS'. Failure to do so will result in the script not being able to capture a successful startup response as soon as possible.\n\nNote that the options passed directly in to the script will supersede the environment variable configuration.\n\nUsage: ./startupHealthCheck.sh <option>...\nOptions:\n\n\t-t/--timeout-seconds\n\t\t A numerical value that must match the timeoutSeconds field of the Kubernetes startup probe configuration. The timeout value is used by this script to establish a timeout duration. Defaults to 1 (second).\n\n\t-f/--file\n\t\tThis value is used to inform the script of the location of the 'started' health-check file. The default is '/output/health/started'\n"
+	  exit 1
+	  ;;
+    *)
+     shift
+     ;;
+  esac
+done
+
+countdown=$timeout_milliseconds
+while [ $countdown -gt 0 ]
+do
+  cat ${started_file}
+  #Succesful `cat`, return 0
+  if [ $? -eq 0 ]
+  then
+    # Delete file before returning 0. Avoid issues where image/pod crashes and /output is a PV. 
+	# This would lead to a pre-existing file when pod is restarted
+    rm ${started_file}
+    exit 0
+  fi
+  sleep ${sleep_seconds}
+  countdown=$((countdown - sleep_milliseconds))
+done
+
+#Default to 1 if we never achieved succesful check.
+exit 1


### PR DESCRIPTION
This introduces three new scripts:
1. `startupHealthCheck.sh`
2. `livenessHealthCheck.sh`
3. `readinessHealthCheck.sh`

These are to be intended to be used with the `exec` command when configuring Kubernetes health check probe.

**Startup script**

The startup health check script require a time out seconds parameter (defaults to 1s). This should match the startup probe's timeout field if configured. The 1s default is the Kubernetes default for `timeoutSeconds`. This will check every 10ms until timeout.
This allows for the script to quickly ascertain a startup UP status within the second intervals of probe execution. Timing out will return 1 (failure to Kubernetes) and if success a 0 will be returned (success for Kubernetes). The 'started' file will be deleted before returning 0 to avoid any crashes of the pod that may lead to a residual `started` file. This is most problematic for `output` directories that are used as persisted volumes.

For example, strictly using an exec command every second (i.e. assuming periodSeconds is 1) means it can be delayed in reporting an UP status if the application starts and reports an UP status at 675ms. Kubernetes will not know until the 1s mark at which point the probe fires again.

- The startup script accepts the -t or --timeout-seconds option for receiving a timeout configuration. Default is 1. Script accepts a `STARTUP_PROBE_TIMEOUT_SECONDS` env var. Script parameter will supersede env var if both are present.
- The startup script accepts the -f or --file option for receiving a configuration regarding the location of the `started` file. Default is `/output/health/started`. Script accepts a `STARTED_FILE_LOCATION` env var. Script parameter will supersede env var if both are present.

**Liveness and readiness script**

The liveness and readiness script are there to determine the status of liveness and readiness respectively. It does so by checking if the file exists. If it does it'll check the last modified time based on the period seconds parameter provided to the script. This period seconds parameter must match the `periodSeconds` configuration of the respective probe. The script will default to 10 (seconds) if not defined. This is also the Kubernetes default for the `periodSeconds` field. If the file has been updated within the past period seconds than the status is UP and the script will return 0. Otherwise it will return 1 and indicate a DOWN status.

- The respective scripts accepts the -p or --period-seconds option for receiving a period seconds configuration. Default is 10 (seconds). Script accepts a `LIVENESS_PROBE_PERIOD_SECONDS` or `READINESS_PROBE_PERIOD_SECONDS` env var. Script parameter will supersede env var if both are present.
- The respective scripts accepts the -f or --file option for receiving a configuration regarding the location of the `live` or `ready` file. Default is `/output/health/live` and `/output/health.ready`. Script accepts a `LIVE_FILE_LOCATION` or `READY_FILE_LOCATION` env var. Script parameter will supersede env var if both are present.
