### PR TITLE
Move MP Health health check scripts to release (through vNext)

### DIFF
--- a/releases/latest/full/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/full/Dockerfile.ubi.ibmjava8
@@ -95,7 +95,7 @@ RUN yum -y install openssl \
     && yum clean all
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubi.openjdk11
+++ b/releases/latest/full/Dockerfile.ubi.openjdk11
@@ -95,7 +95,7 @@ RUN yum -y install openssl \
     && yum clean all
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubi.openjdk17
+++ b/releases/latest/full/Dockerfile.ubi.openjdk17
@@ -95,7 +95,7 @@ RUN yum -y install openssl \
     && yum clean all
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubi.openjdk8
+++ b/releases/latest/full/Dockerfile.ubi.openjdk8
@@ -95,7 +95,7 @@ RUN yum -y install openssl \
     && yum clean all
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk11
@@ -73,7 +73,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk17
@@ -73,7 +73,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk8
@@ -73,7 +73,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/full/helpers/runtime/livenessHealthCheck.sh
+++ b/releases/latest/full/helpers/runtime/livenessHealthCheck.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+#Default to Kubernetes default for periodSeconds of 10 seconds
+period_seconds=10
+period_milliseconds=$((period_seconds * 1000))
+
+#Default location for 'live' file - Can change through parameter or server env
+live_file=/output/health/live
+
+
+# Evaluate if there is a env var for periodSeconds
+if [ -n "${LIVENESS_PROBE_PERIOD_SECONDS}" ]
+then
+  #Check input is numerical only
+  if [[ ${LIVENESS_PROBE_PERIOD_SECONDS} =~ ^[0-9]+$ ]]
+  then
+    period_seconds=${LIVENESS_PROBE_PERIOD_SECONDS}
+    period_milliseconds=$((period_seconds * 1000))
+  else
+    echo "Expected only a numerical value for LIVENESS_PROBE_PERIOD_SECONDS environment variable, but recieved: ${LIVENESS_PROBE_PERIOD_SECONDS}. This value will not be used."
+  fi
+fi
+
+# Evaluate if there is a env var for 'live' file location
+if [ -n "${LIVE_FILE_LOCATION}" ]
+then
+  live_file=${LIVE_FILE_LOCATION}
+fi
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -p|--period-seconds)
+      #Check input is numerical only
+      if [[ $2 =~ ^[0-9]+$ ]]
+      then
+        period_seconds=$2
+        period_milliseconds=$((period_seconds*1000))
+      else
+        echo "Expected only a numerical value for the -p/--period-seconds parameter, but recieved: $2. Defaulting to 10 second period seconds or environment variable defined value if valid."
+      fi
+      shift
+      shift
+      ;;
+    -f|--file)
+      live_file=$2
+      shift
+      shift
+      ;;
+	--help)
+	  printf "This script is used to query the 'live' health check file to determine if the container is live or not. The default location is '/output/health/live' but can be configured with the '-f' or '--file' option or with the environment variable 'LIVE_FILE_LOCATION' if the file exists in another location. This script will check whether the file has been updated or not within the last 'period seconds' (default is 10 seconds). This value can be configured with the '-p' or '--period-seconds' option or with the 'LIVENESS_PROBE_PERIOD_SECONDS' environment variable. It is important to configure the period seconds option for this script if the Kubernetes 'periodSeconds' field of the liveness probe is configured. Failure to do so will result in misreporting of the liveness status of the container.\n\nNote that the options passed directly in to the script will supersede the environment variable configuration.\n\nUsage: ./livenessHealthCheck.sh <option>...\nOptions:\n\n\t-p/--period-seconds\n\t\t A numerical value that must match the periodSeconds field of the Kubernetes liveness probe configuration. The period seconds value is used by this script to determine if the container is live or not. Default is 10 (seconds).\n\n\t-f/--file\n\t\tThis value is used to inform the script of the location of the 'live' health-check file. The default is '/output/health/live'\n"
+	  exit 1
+	  ;;
+    *)
+     shift
+     ;;
+  esac
+done
+
+cat $live_file
+
+if [ $? -ne 0 ]
+then  
+  exit 1
+fi
+
+#What is the last modified time of the file
+modified_time=$(stat --format=%.3Y $live_file | tr -d ".") 
+
+
+if [ $(expr $(date +%s%3N) - $modified_time) -gt $period_milliseconds ]
+then
+  #File has not been updated within the last period_milliseconds; fail
+  exit 1
+else
+  #File has been updated within the last period_milliseconds; success!
+  exit 0
+fi

--- a/releases/latest/full/helpers/runtime/readinessHealthCheck.sh
+++ b/releases/latest/full/helpers/runtime/readinessHealthCheck.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+#Default to Kubernetes default for periodSeconds of 10 seconds
+period_seconds=10
+period_milliseconds=$((period_seconds * 1000))
+
+#Default location for 'ready' file - Can change through parameter or server env
+ready_file=/output/health/ready
+
+
+# Evaluate if there is a env var for periodSeconds
+if [ -n "${READINESS_PROBE_PERIOD_SECONDS}" ]
+then
+  #Check input is numerical only
+  if [[ ${READINESS_PROBE_PERIOD_SECONDS} =~ ^[0-9]+$ ]]
+  then
+    period_seconds=${READINESS_PROBE_PERIOD_SECONDS}
+    period_milliseconds=$((period_seconds * 1000))
+  else
+    echo "Expected only a numerical value for READINESS_PROBE_PERIOD_SECONDS environment variable, but recieved: ${READINESS_PROBE_PERIOD_SECONDS}. This value will not be used."
+  fi
+fi
+
+# Evaluate if there is a env var for 'ready' file location
+if [ -n "${READY_FILE_LOCATION}" ]
+then
+  ready_file=${READY_FILE_LOCATION}
+fi
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -p|--period-seconds)
+      #Check input is numerical only
+      if [[ $2 =~ ^[0-9]+$ ]]
+      then
+        period_seconds=$2
+        period_milliseconds=$((period_seconds*1000))
+      else
+        echo "Expected only a numerical value for the -p/--period-seconds parameter, but recieved: $2. Defaulting to 10 second period seconds or environment variable defined value if valid."
+      fi
+      shift
+      shift
+      ;;
+    -f|--file)
+      ready_file=$2
+      shift
+      shift
+      ;;
+	--help)
+	  printf "This script is used to query the 'ready' health check file to determine if the container is ready or not. The default location is '/output/health/ready' but can be configured with the '-f' or '--file' option or with the environment variable 'READY_FILE_LOCATION' if the file exists in another location. This script will check whether the file has been updated or not within the last 'period seconds' (default is 10 seconds). This value can be configured with the '-p' or '--period-seconds' option or with the 'READINESS_PROBE_PERIOD_SECONDS' environment variable. It is important to configure the period seconds option for this script if the Kubernetes 'periodSeconds' field of the readiness probe is configured. Failure to do so will result in misreporting of the readiness status of the container.\n\nNote that the options passed directly in to the script will supersede the environment variable configuration.\n\nUsage: ./readinessHealthCheck.sh <option>...\nOptions:\n\n\t-p/--period-seconds\n\t\t A numerical value that must match the periodSeconds field of the Kubernetes readiness probe configuration. The period seconds value is used by this script to determine if the container is ready or not. Default is 10 (seconds).\n\n\t-f/--file\n\t\tThis value is used to inform the script of the location of the 'ready' health-check file. The default is '/output/health/ready'\n"
+	  exit 1
+	  ;;
+    *)
+     shift
+     ;;
+  esac
+done
+
+cat $ready_file
+
+if [ $? -ne 0 ]
+then  
+  exit 1
+fi
+
+#What is the last modified time of the file
+modified_time=$(stat --format=%.3Y $ready_file | tr -d ".") 
+
+
+if [ $(expr $(date +%s%3N) - $modified_time) -gt $period_milliseconds ]
+then
+  #File has not been updated within the last period_milliseconds; fail
+  exit 1
+else
+  #File has been updated within the last period_milliseconds; success!
+  exit 0
+fi

--- a/releases/latest/full/helpers/runtime/startupHealthCheck.sh
+++ b/releases/latest/full/helpers/runtime/startupHealthCheck.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+#Default to 1s - Can change through parameter or server env
+timeout_seconds=1
+timeout_milliseconds=$((timeout_seconds * 1000))
+
+#Default location for 'started' file - Can change through parameter or server env
+started_file=/output/health/started
+
+#Static values - will not be changed
+sleep_seconds=0.01
+sleep_milliseconds=10
+
+
+# Evaluate if there is a env var for timeoutSeconds
+if [ -n "${STARTUP_PROBE_TIMEOUT_SECONDS}" ]
+then
+  #Check input is numerical only
+  if [[ ${STARTUP_PROBE_TIMEOUT_SECONDS} =~ ^[0-9]+$ ]]
+  then
+    timeout_seconds=${STARTUP_PROBE_TIMEOUT_SECONDS}
+    timeout_milliseconds=$((timeout_seconds * 1000))
+  else
+    echo "Expected only a numerical value for STARTUP_PROBE_TIMEOUT_SECONDS environment variable, but recieved: ${STARTUP_PROBE_TIMEOUT_SECONDS}. This value will not be used."
+  fi
+fi
+
+# Evaluate if there is a env var for 'started' file location
+if [ -n "${STARTED_FILE_LOCATION}" ]
+then
+  started_file=${STARTED_FILE_LOCATION}
+fi
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -t|--timeout-seconds)
+      #Check input is numerical only
+      if [[ $2 =~ ^[0-9]+$ ]]
+      then
+        timeout_seconds=$2
+        timeout_milliseconds=$((timeout_seconds*1000))
+      else
+        echo "Expected only a numerical value for the -t/--timeout-seconds parameter, but recieved: $2. Defaulting to 1 second timeoutSeconds or environment variable defined value if valid."
+      fi
+      shift
+      shift
+      ;;
+    -f|--file)
+      started_file=$2
+      shift
+      shift
+      ;;
+	--help)
+	  printf "This script is used to query the 'started' health check file to determine if the container is started. The default location is '/output/health/started' but can be configured with the '-f' or '--file' option or the environment variable 'STARTED_FILE_LOCATION' if the file exists in another location. This script will check until the timeout duration has expired (default is 1 second) unless configured otherwise. Configuring the timeout option for this script is important if the 'timeoutSeconds' field of the Kubernetes startup probe is configured. This can be achieved by using the '-t' or '--timeout-seconds' option or with the environment variable 'STARTUP_PROBE_TIMEOUT_SECONDS'. Failure to do so will result in the script not being able to capture a successful startup response as soon as possible.\n\nNote that the options passed directly into the script will supersede the environment variable configuration.\n\nUsage: ./startupHealthCheck.sh <option>...\nOptions:\n\n\t-t/--timeout-seconds\n\t\t A numerical value that must match the 'timeoutSeconds' field of the Kubernetes startup probe configuration. The timeout value is used by this script to establish a timeout duration. Defaults to 1 (second).\n\n\t-f/--file\n\t\tThis value is used to inform the script of the location of the 'started' health-check file. The default is '/output/health/started'\n"
+	  exit 1
+	  ;;
+    *)
+     shift
+     ;;
+  esac
+done
+
+countdown=$timeout_milliseconds
+while [ $countdown -gt 0 ]
+do
+  cat ${started_file}
+  #Succesful `cat`, return 0
+  if [ $? -eq 0 ]
+  then
+    # Delete file before returning 0. Avoid issues where image/pod crashes and /output is a PV. 
+	# This would lead to a pre-existing file when pod is restarted
+    rm ${started_file}
+    exit 0
+  fi
+  sleep ${sleep_seconds}
+  countdown=$((countdown - sleep_milliseconds))
+done
+
+#Default to 1 if we never achieved succesful check.
+exit 1

--- a/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.ibmjava8
@@ -95,7 +95,7 @@ RUN yum -y install openssl \
     && yum clean all
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk11
@@ -95,7 +95,7 @@ RUN yum -y install openssl \
     && yum clean all
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk17
@@ -95,7 +95,7 @@ RUN yum -y install openssl \
     && yum clean all
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi.openjdk8
@@ -95,7 +95,7 @@ RUN yum -y install openssl \
     && yum clean all
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi9-minimal.ibmjava8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi9-minimal.ibmjava8
@@ -105,7 +105,7 @@ COPY --from=getRuntime /licenses /licenses
 
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi9-minimal.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubi9-minimal.openjdk11
@@ -96,7 +96,7 @@ COPY --from=getRuntime /licenses /licenses
 
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi9-minimal.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubi9-minimal.openjdk17
@@ -96,7 +96,7 @@ COPY --from=getRuntime /licenses /licenses
 
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi9-minimal.openjdk21
+++ b/releases/latest/kernel-slim/Dockerfile.ubi9-minimal.openjdk21
@@ -96,7 +96,7 @@ COPY --from=getRuntime /licenses /licenses
 
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubi9-minimal.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubi9-minimal.openjdk8
@@ -96,7 +96,7 @@ COPY --from=getRuntime /licenses /licenses
 
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -73,7 +73,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp 
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -73,7 +73,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp 
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -73,7 +73,7 @@ RUN apt-get update \
     && chmod -R g+rw /opt/ol/wlp 
 
 # Set Path Shortcuts
-ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build \
+ENV PATH=$PATH:/opt/ol/wlp/bin:/opt/ol/helpers/build:/opt/ol/helpers/runtime \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true \

--- a/releases/latest/kernel-slim/helpers/runtime/livenessHealthCheck.sh
+++ b/releases/latest/kernel-slim/helpers/runtime/livenessHealthCheck.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+#Default to Kubernetes default for periodSeconds of 10 seconds
+period_seconds=10
+period_milliseconds=$((period_seconds * 1000))
+
+#Default location for 'live' file - Can change through parameter or server env
+live_file=/output/health/live
+
+
+# Evaluate if there is a env var for periodSeconds
+if [ -n "${LIVENESS_PROBE_PERIOD_SECONDS}" ]
+then
+  #Check input is numerical only
+  if [[ ${LIVENESS_PROBE_PERIOD_SECONDS} =~ ^[0-9]+$ ]]
+  then
+    period_seconds=${LIVENESS_PROBE_PERIOD_SECONDS}
+    period_milliseconds=$((period_seconds * 1000))
+  else
+    echo "Expected only a numerical value for LIVENESS_PROBE_PERIOD_SECONDS environment variable, but recieved: ${LIVENESS_PROBE_PERIOD_SECONDS}. This value will not be used."
+  fi
+fi
+
+# Evaluate if there is a env var for 'live' file location
+if [ -n "${LIVE_FILE_LOCATION}" ]
+then
+  live_file=${LIVE_FILE_LOCATION}
+fi
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -p|--period-seconds)
+      #Check input is numerical only
+      if [[ $2 =~ ^[0-9]+$ ]]
+      then
+        period_seconds=$2
+        period_milliseconds=$((period_seconds*1000))
+      else
+        echo "Expected only a numerical value for the -p/--period-seconds parameter, but recieved: $2. Defaulting to 10 second period seconds or environment variable defined value if valid."
+      fi
+      shift
+      shift
+      ;;
+    -f|--file)
+      live_file=$2
+      shift
+      shift
+      ;;
+	--help)
+	  printf "This script is used to query the 'live' health check file to determine if the container is live or not. The default location is '/output/health/live' but can be configured with the '-f' or '--file' option or with the environment variable 'LIVE_FILE_LOCATION' if the file exists in another location. This script will check whether the file has been updated or not within the last 'period seconds' (default is 10 seconds). This value can be configured with the '-p' or '--period-seconds' option or with the 'LIVENESS_PROBE_PERIOD_SECONDS' environment variable. It is important to configure the period seconds option for this script if the Kubernetes 'periodSeconds' field of the liveness probe is configured. Failure to do so will result in misreporting of the liveness status of the container.\n\nNote that the options passed directly in to the script will supersede the environment variable configuration.\n\nUsage: ./livenessHealthCheck.sh <option>...\nOptions:\n\n\t-p/--period-seconds\n\t\t A numerical value that must match the periodSeconds field of the Kubernetes liveness probe configuration. The period seconds value is used by this script to determine if the container is live or not. Default is 10 (seconds).\n\n\t-f/--file\n\t\tThis value is used to inform the script of the location of the 'live' health-check file. The default is '/output/health/live'\n"
+	  exit 1
+	  ;;
+    *)
+     shift
+     ;;
+  esac
+done
+
+cat $live_file
+
+if [ $? -ne 0 ]
+then  
+  exit 1
+fi
+
+#What is the last modified time of the file
+modified_time=$(stat --format=%.3Y $live_file | tr -d ".") 
+
+
+if [ $(expr $(date +%s%3N) - $modified_time) -gt $period_milliseconds ]
+then
+  #File has not been updated within the last period_milliseconds; fail
+  exit 1
+else
+  #File has been updated within the last period_milliseconds; success!
+  exit 0
+fi

--- a/releases/latest/kernel-slim/helpers/runtime/readinessHealthCheck.sh
+++ b/releases/latest/kernel-slim/helpers/runtime/readinessHealthCheck.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+#Default to Kubernetes default for periodSeconds of 10 seconds
+period_seconds=10
+period_milliseconds=$((period_seconds * 1000))
+
+#Default location for 'ready' file - Can change through parameter or server env
+ready_file=/output/health/ready
+
+
+# Evaluate if there is a env var for periodSeconds
+if [ -n "${READINESS_PROBE_PERIOD_SECONDS}" ]
+then
+  #Check input is numerical only
+  if [[ ${READINESS_PROBE_PERIOD_SECONDS} =~ ^[0-9]+$ ]]
+  then
+    period_seconds=${READINESS_PROBE_PERIOD_SECONDS}
+    period_milliseconds=$((period_seconds * 1000))
+  else
+    echo "Expected only a numerical value for READINESS_PROBE_PERIOD_SECONDS environment variable, but recieved: ${READINESS_PROBE_PERIOD_SECONDS}. This value will not be used."
+  fi
+fi
+
+# Evaluate if there is a env var for 'ready' file location
+if [ -n "${READY_FILE_LOCATION}" ]
+then
+  ready_file=${READY_FILE_LOCATION}
+fi
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -p|--period-seconds)
+      #Check input is numerical only
+      if [[ $2 =~ ^[0-9]+$ ]]
+      then
+        period_seconds=$2
+        period_milliseconds=$((period_seconds*1000))
+      else
+        echo "Expected only a numerical value for the -p/--period-seconds parameter, but recieved: $2. Defaulting to 10 second period seconds or environment variable defined value if valid."
+      fi
+      shift
+      shift
+      ;;
+    -f|--file)
+      ready_file=$2
+      shift
+      shift
+      ;;
+	--help)
+	  printf "This script is used to query the 'ready' health check file to determine if the container is ready or not. The default location is '/output/health/ready' but can be configured with the '-f' or '--file' option or with the environment variable 'READY_FILE_LOCATION' if the file exists in another location. This script will check whether the file has been updated or not within the last 'period seconds' (default is 10 seconds). This value can be configured with the '-p' or '--period-seconds' option or with the 'READINESS_PROBE_PERIOD_SECONDS' environment variable. It is important to configure the period seconds option for this script if the Kubernetes 'periodSeconds' field of the readiness probe is configured. Failure to do so will result in misreporting of the readiness status of the container.\n\nNote that the options passed directly in to the script will supersede the environment variable configuration.\n\nUsage: ./readinessHealthCheck.sh <option>...\nOptions:\n\n\t-p/--period-seconds\n\t\t A numerical value that must match the periodSeconds field of the Kubernetes readiness probe configuration. The period seconds value is used by this script to determine if the container is ready or not. Default is 10 (seconds).\n\n\t-f/--file\n\t\tThis value is used to inform the script of the location of the 'ready' health-check file. The default is '/output/health/ready'\n"
+	  exit 1
+	  ;;
+    *)
+     shift
+     ;;
+  esac
+done
+
+cat $ready_file
+
+if [ $? -ne 0 ]
+then  
+  exit 1
+fi
+
+#What is the last modified time of the file
+modified_time=$(stat --format=%.3Y $ready_file | tr -d ".") 
+
+
+if [ $(expr $(date +%s%3N) - $modified_time) -gt $period_milliseconds ]
+then
+  #File has not been updated within the last period_milliseconds; fail
+  exit 1
+else
+  #File has been updated within the last period_milliseconds; success!
+  exit 0
+fi

--- a/releases/latest/kernel-slim/helpers/runtime/startupHealthCheck.sh
+++ b/releases/latest/kernel-slim/helpers/runtime/startupHealthCheck.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+#Default to 1s - Can change through parameter or server env
+timeout_seconds=1
+timeout_milliseconds=$((timeout_seconds * 1000))
+
+#Default location for 'started' file - Can change through parameter or server env
+started_file=/output/health/started
+
+#Static values - will not be changed
+sleep_seconds=0.01
+sleep_milliseconds=10
+
+
+# Evaluate if there is a env var for timeoutSeconds
+if [ -n "${STARTUP_PROBE_TIMEOUT_SECONDS}" ]
+then
+  #Check input is numerical only
+  if [[ ${STARTUP_PROBE_TIMEOUT_SECONDS} =~ ^[0-9]+$ ]]
+  then
+    timeout_seconds=${STARTUP_PROBE_TIMEOUT_SECONDS}
+    timeout_milliseconds=$((timeout_seconds * 1000))
+  else
+    echo "Expected only a numerical value for STARTUP_PROBE_TIMEOUT_SECONDS environment variable, but recieved: ${STARTUP_PROBE_TIMEOUT_SECONDS}. This value will not be used."
+  fi
+fi
+
+# Evaluate if there is a env var for 'started' file location
+if [ -n "${STARTED_FILE_LOCATION}" ]
+then
+  started_file=${STARTED_FILE_LOCATION}
+fi
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -t|--timeout-seconds)
+      #Check input is numerical only
+      if [[ $2 =~ ^[0-9]+$ ]]
+      then
+        timeout_seconds=$2
+        timeout_milliseconds=$((timeout_seconds*1000))
+      else
+        echo "Expected only a numerical value for the -t/--timeout-seconds parameter, but recieved: $2. Defaulting to 1 second timeoutSeconds or environment variable defined value if valid."
+      fi
+      shift
+      shift
+      ;;
+    -f|--file)
+      started_file=$2
+      shift
+      shift
+      ;;
+	--help)
+	  printf "This script is used to query the 'started' health check file to determine if the container is started. The default location is '/output/health/started' but can be configured with the '-f' or '--file' option or the environment variable 'STARTED_FILE_LOCATION' if the file exists in another location. This script will check until the timeout duration has expired (default is 1 second) unless configured otherwise. Configuring the timeout option for this script is important if the 'timeoutSeconds' field of the Kubernetes startup probe is configured. This can be achieved by using the '-t' or '--timeout-seconds' option or with the environment variable 'STARTUP_PROBE_TIMEOUT_SECONDS'. Failure to do so will result in the script not being able to capture a successful startup response as soon as possible.\n\nNote that the options passed directly into the script will supersede the environment variable configuration.\n\nUsage: ./startupHealthCheck.sh <option>...\nOptions:\n\n\t-t/--timeout-seconds\n\t\t A numerical value that must match the 'timeoutSeconds' field of the Kubernetes startup probe configuration. The timeout value is used by this script to establish a timeout duration. Defaults to 1 (second).\n\n\t-f/--file\n\t\tThis value is used to inform the script of the location of the 'started' health-check file. The default is '/output/health/started'\n"
+	  exit 1
+	  ;;
+    *)
+     shift
+     ;;
+  esac
+done
+
+countdown=$timeout_milliseconds
+while [ $countdown -gt 0 ]
+do
+  cat ${started_file}
+  #Succesful `cat`, return 0
+  if [ $? -eq 0 ]
+  then
+    # Delete file before returning 0. Avoid issues where image/pod crashes and /output is a PV. 
+	# This would lead to a pre-existing file when pod is restarted
+    rm ${started_file}
+    exit 0
+  fi
+  sleep ${sleep_seconds}
+  countdown=$((countdown - sleep_milliseconds))
+done
+
+#Default to 1 if we never achieved succesful check.
+exit 1


### PR DESCRIPTION
Also adds `helpers/runtime` folder to PATH.

See the original introduction of file from: https://github.com/OpenLiberty/ci.docker/pull/629