### PR TITLE
Explicitly specify the default keystore location and type in keystore.xml

### DIFF
--- a/releases/25.0.0.6/full/helpers/build/configuration_snippets/keystore.xml
+++ b/releases/25.0.0.6/full/helpers/build/configuration_snippets/keystore.xml
@@ -1,3 +1,3 @@
 <server description="Default Server">
-    <keyStore id="defaultKeyStore" password="REPLACE" />
+    <keyStore id="defaultKeyStore" location="${server.output.dir}/resources/security/key.p12" type="PKCS12" password="REPLACE" />
 </server>

--- a/releases/25.0.0.6/kernel-slim/helpers/build/configuration_snippets/keystore.xml
+++ b/releases/25.0.0.6/kernel-slim/helpers/build/configuration_snippets/keystore.xml
@@ -1,3 +1,3 @@
 <server description="Default Server">
-    <keyStore id="defaultKeyStore" password="REPLACE" />
+    <keyStore id="defaultKeyStore" location="${server.output.dir}/resources/security/key.p12" type="PKCS12" password="REPLACE" />
 </server>

--- a/releases/latest/beta/helpers/build/configuration_snippets/keystore.xml
+++ b/releases/latest/beta/helpers/build/configuration_snippets/keystore.xml
@@ -1,3 +1,3 @@
 <server description="Default Server">
-    <keyStore id="defaultKeyStore" password="REPLACE" />
+    <keyStore id="defaultKeyStore" location="${server.output.dir}/resources/security/key.p12" type="PKCS12" password="REPLACE" />
 </server>

--- a/releases/latest/full/helpers/build/configuration_snippets/keystore.xml
+++ b/releases/latest/full/helpers/build/configuration_snippets/keystore.xml
@@ -1,3 +1,3 @@
 <server description="Default Server">
-    <keyStore id="defaultKeyStore" password="REPLACE" />
+    <keyStore id="defaultKeyStore" location="${server.output.dir}/resources/security/key.p12" type="PKCS12" password="REPLACE" />
 </server>

--- a/releases/latest/kernel-slim/helpers/build/configuration_snippets/keystore.xml
+++ b/releases/latest/kernel-slim/helpers/build/configuration_snippets/keystore.xml
@@ -1,3 +1,3 @@
 <server description="Default Server">
-    <keyStore id="defaultKeyStore" password="REPLACE" />
+    <keyStore id="defaultKeyStore" location="${server.output.dir}/resources/security/key.p12" type="PKCS12" password="REPLACE" />
 </server>


### PR DESCRIPTION
Explicitly specify the default keystore location and type in keystore.xml

This is a safe change to make as the added keystore location and type are the default values. But helps to avoid mismatched keystore values in scenarios where the user has also configured the keystore in their server.xml (i.e. not just the password field, but also the location and/or type). In scenarios where the keystore.xml is copied to the configDropins/defaults directory, it could be overridden by the user. In scenarios where Liberty container creates the keystore, the config written to configDropins/overrides directory would take precedence over the config in server.xml (i.e. user specified another location).