### PR TITLE
Remove deprecation message

### DIFF
--- a/releases/25.0.0.11/full/helpers/build/internal/logger.sh
+++ b/releases/25.0.0.11/full/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/releases/25.0.0.11/kernel-slim/helpers/build/internal/logger.sh
+++ b/releases/25.0.0.11/kernel-slim/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/releases/25.0.0.3/full/helpers/build/internal/logger.sh
+++ b/releases/25.0.0.3/full/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/releases/25.0.0.3/kernel-slim/helpers/build/internal/logger.sh
+++ b/releases/25.0.0.3/kernel-slim/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/releases/25.0.0.6/full/helpers/build/internal/logger.sh
+++ b/releases/25.0.0.6/full/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/releases/25.0.0.6/kernel-slim/helpers/build/internal/logger.sh
+++ b/releases/25.0.0.6/kernel-slim/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/releases/25.0.0.9/full/helpers/build/internal/logger.sh
+++ b/releases/25.0.0.9/full/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/releases/25.0.0.9/kernel-slim/helpers/build/internal/logger.sh
+++ b/releases/25.0.0.9/kernel-slim/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/releases/latest/beta/helpers/build/internal/logger.sh
+++ b/releases/latest/beta/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/releases/latest/full/helpers/build/internal/logger.sh
+++ b/releases/latest/full/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/releases/latest/kernel-slim/helpers/build/internal/logger.sh
+++ b/releases/latest/kernel-slim/helpers/build/internal/logger.sh
@@ -14,10 +14,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/open-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main


### PR DESCRIPTION
Now that we've stopped pushing UBI images to Docker Hub, we can remove the deprecation message. Users still pulling images from Docker Hub would still see that message (from the old images that they pull). 