### PR TITLE
Only run `set -x` if VERBOSE is specified

### DIFF
--- a/releases/latest/beta/helpers/build/configure.sh
+++ b/releases/latest/beta/helpers/build/configure.sh
@@ -2,7 +2,7 @@
 
 . /opt/ol/helpers/build/internal/logger.sh
 
-set -Eeox pipefail
+set -Eeo pipefail
 
 function main() {
   ##Define variables for XML snippets source and target paths

--- a/releases/latest/beta/helpers/build/infinispan-client-setup.sh
+++ b/releases/latest/beta/helpers/build/infinispan-client-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . /opt/ol/helpers/build/internal/logger.sh
 
-set -Eeox pipefail
+set -Eeo pipefail
 
 pkgcmd=yum
 if ! command $pkgcmd

--- a/releases/latest/beta/helpers/build/internal/logger.sh
+++ b/releases/latest/beta/helpers/build/internal/logger.sh
@@ -3,6 +3,8 @@
 function main() {
     if [ "$VERBOSE" != "true" ]; then
         exec >/dev/null
+    else
+        set -x
     fi
 }
 

--- a/releases/latest/beta/helpers/build/populate_scc.sh
+++ b/releases/latest/beta/helpers/build/populate_scc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . /opt/ol/helpers/build/internal/logger.sh
 
-set -Eeox pipefail
+set -Eeo pipefail
 
 SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.

--- a/releases/latest/full/helpers/build/configure.sh
+++ b/releases/latest/full/helpers/build/configure.sh
@@ -2,7 +2,7 @@
 
 . /opt/ol/helpers/build/internal/logger.sh
 
-set -Eeox pipefail
+set -Eeo pipefail
 
 function main() {
   ##Define variables for XML snippets source and target paths

--- a/releases/latest/full/helpers/build/infinispan-client-setup.sh
+++ b/releases/latest/full/helpers/build/infinispan-client-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . /opt/ol/helpers/build/internal/logger.sh
 
-set -Eeox pipefail
+set -Eeo pipefail
 
 pkgcmd=yum
 if ! command $pkgcmd

--- a/releases/latest/full/helpers/build/internal/logger.sh
+++ b/releases/latest/full/helpers/build/internal/logger.sh
@@ -3,6 +3,8 @@
 function main() {
     if [ "$VERBOSE" != "true" ]; then
         exec >/dev/null
+    else
+        set -x
     fi
 }
 

--- a/releases/latest/full/helpers/build/populate_scc.sh
+++ b/releases/latest/full/helpers/build/populate_scc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . /opt/ol/helpers/build/internal/logger.sh
 
-set -Eeox pipefail
+set -Eeo pipefail
 
 SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.

--- a/releases/latest/kernel-slim/helpers/build/configure.sh
+++ b/releases/latest/kernel-slim/helpers/build/configure.sh
@@ -2,7 +2,7 @@
 
 . /opt/ol/helpers/build/internal/logger.sh
 
-set -Eeox pipefail
+set -Eeo pipefail
 
 function main() {
   ##Define variables for XML snippets source and target paths

--- a/releases/latest/kernel-slim/helpers/build/features.sh
+++ b/releases/latest/kernel-slim/helpers/build/features.sh
@@ -2,7 +2,7 @@
 
 . /opt/ol/helpers/build/internal/logger.sh
 
-set -Eeox pipefail
+set -Eeo pipefail
 
 ##Define variables for XML snippets source and target paths
 SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets

--- a/releases/latest/kernel-slim/helpers/build/infinispan-client-setup.sh
+++ b/releases/latest/kernel-slim/helpers/build/infinispan-client-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . /opt/ol/helpers/build/internal/logger.sh
 
-set -Eeox pipefail
+set -Eeo pipefail
 
 pkgcmd=yum
 if ! command $pkgcmd

--- a/releases/latest/kernel-slim/helpers/build/internal/logger.sh
+++ b/releases/latest/kernel-slim/helpers/build/internal/logger.sh
@@ -3,6 +3,8 @@
 function main() {
     if [ "$VERBOSE" != "true" ]; then
         exec >/dev/null
+    else
+        set -x
     fi
 }
 

--- a/releases/latest/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel-slim/helpers/build/populate_scc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . /opt/ol/helpers/build/internal/logger.sh
 
-set -Eeox pipefail
+set -Eeo pipefail
 
 SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.


### PR DESCRIPTION
To reduce default output, but still allow debugging if required.
Deals with #681
