### PR TITLE
Update the base Semeru image for Ubuntu

### DIFF
--- a/releases/26.0.0.1/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/26.0.0.1/full/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-noble
 
 USER root
 

--- a/releases/26.0.0.1/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/26.0.0.1/full/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-noble
 
 USER root
 

--- a/releases/26.0.0.1/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/26.0.0.1/full/Dockerfile.ubuntu.openjdk8
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-8-jre-jammy
+FROM ibm-semeru-runtimes:open-8-jre-noble
 
 USER root
 

--- a/releases/26.0.0.1/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/26.0.0.1/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-noble
 
 USER root
 

--- a/releases/26.0.0.1/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/26.0.0.1/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-noble
 
 USER root
 

--- a/releases/26.0.0.1/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/26.0.0.1/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-8-jre-jammy
+FROM ibm-semeru-runtimes:open-8-jre-noble
 
 USER root
 

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-noble
 
 USER root
 

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-noble
 
 USER root
 

--- a/releases/latest/beta/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/beta/Dockerfile.ubuntu.openjdk8
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-8-jre-jammy
+FROM ibm-semeru-runtimes:open-8-jre-noble
 
 USER root
 

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-noble
 
 USER root
 

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-noble
 
 USER root
 

--- a/releases/latest/full/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/full/Dockerfile.ubuntu.openjdk8
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-8-jre-jammy
+FROM ibm-semeru-runtimes:open-8-jre-noble
 
 USER root
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-noble
 
 USER root
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-noble
 
 USER root
 

--- a/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
+++ b/releases/latest/kernel-slim/Dockerfile.ubuntu.openjdk8
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-8-jre-jammy
+FROM ibm-semeru-runtimes:open-8-jre-noble
 
 USER root
 


### PR DESCRIPTION
Update base Semeru image for Ubuntu to use noble instead of jammy to resolve security vulnerabilities. This change will be effective in Liberty 26.0.0.1 container images and onwards. 