### PR TITLE
Prevent temporarily changed .gitignore file from being committed and pushed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,10 @@ repos:
         # when "--baseline" with "--use-all-plugins", pre-commit scan with all available plugins
         # add "--fail-on-unaudited" to fail pre-commit for unaudited potential secrets
         args: [--baseline, .secrets.baseline, --use-all-plugins]
+  - repo: local
+    hooks:
+      - id: no-gitignore-commit
+        name: Prevent .gitignore from getting committed
+        entry: ".gitignore file commit detected"
+        language: fail
+        files: ^.gitignore$

--- a/create-new-release.sh
+++ b/create-new-release.sh
@@ -79,5 +79,7 @@ if [[ $(( $OLD_SHORT_VERSION % 3 )) -eq 0 ]]
 # directories can be committed and pushed.
 sed -i'.bak' -e "s/releases\/\*\/\*\/resources\/\*/#releases\/\*\/\*\/resources\/\*/g" .gitignore
 rm ./.gitignore.bak
+git restore .gitignore
 
+echo "**** Please be sure the new release's 'resources' subdirectories are commited and pushed because the vNext pipelines will fail without them. ****"
 echo "Done performing file updates.";

--- a/create-new-release.sh
+++ b/create-new-release.sh
@@ -79,7 +79,8 @@ if [[ $(( $OLD_SHORT_VERSION % 3 )) -eq 0 ]]
 # directories can be committed and pushed.
 sed -i'.bak' -e "s/releases\/\*\/\*\/resources\/\*/#releases\/\*\/\*\/resources\/\*/g" .gitignore
 rm ./.gitignore.bak
-git restore .gitignore
 
-echo "**** Please be sure the new release's 'resources' subdirectories are commited and pushed because the vNext pipelines will fail without them. ****"
 echo "Done performing file updates.";
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "!!!!!! Please do NOT commit and push the changed .gitignore file, which is only a temporary LOCAL change. !!!!!!"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"


### PR DESCRIPTION
Changes to this repo's `.gitignore` file are being unintentionally committed and pushed.

The create-new-release.sh script changes this file to comment out line `releases/*/*/resources/*` in order so that the newly created release's `resources` subdir can be commited and pushed. But, the ignore file has that entry in there so that no zip files that might be placed there in someone's local dir are pushed to the repository.

Recall that the dependency OL image zips are in that subdir because build scripts assume that location.