### PR TITLE
Create the LTPA keys password by default on 26.0.0.5+

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": "REPLACE|PWD_TRUST|SECRET|keyStore|secret"
   },
-  "generated_at": "2026-05-05T14:14:46Z",
+  "generated_at": "2026-05-15T15:52:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -419,10 +419,18 @@
     ],
     "releases/26.0.0.5/full/helpers/runtime/docker-server.sh": [
       {
+        "hashed_secret": "196ce2adfe494f21d7fe2adcd3bcf4ff4e267b92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 104,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ad321232b1e4e90a29208e1f70d06aad788caa16",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 127,
+        "line_number": 133,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -459,10 +467,18 @@
     ],
     "releases/26.0.0.5/kernel-slim/helpers/runtime/docker-server.sh": [
       {
+        "hashed_secret": "196ce2adfe494f21d7fe2adcd3bcf4ff4e267b92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 104,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ad321232b1e4e90a29208e1f70d06aad788caa16",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 127,
+        "line_number": 133,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -519,10 +535,18 @@
     ],
     "releases/latest/full/helpers/runtime/docker-server.sh": [
       {
+        "hashed_secret": "196ce2adfe494f21d7fe2adcd3bcf4ff4e267b92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 104,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ad321232b1e4e90a29208e1f70d06aad788caa16",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 127,
+        "line_number": 133,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -559,10 +583,18 @@
     ],
     "releases/latest/kernel-slim/helpers/runtime/docker-server.sh": [
       {
+        "hashed_secret": "196ce2adfe494f21d7fe2adcd3bcf4ff4e267b92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 104,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ad321232b1e4e90a29208e1f70d06aad788caa16",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 127,
+        "line_number": 133,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This section describes the optional build variables that can be enabled via the 
   *  XML Snippet Location: [hazelcast-sessioncache.xml](/releases/latest/kernel-slim/helpers/build/configuration_snippets/hazelcast-sessioncache.xml)
 * `VERBOSE`
   *  Description: When set to `true` it outputs the commands and results to stdout from `configure.sh`. Otherwise, default setting is `false` and `configure.sh` is silenced.
-* `GENERATE_LTPA_KEYS_PASSWORD` (environment variable, 26.0.0.5+)
+* `GENERATE_LTPA_KEYS_PASSWORD` (26.0.0.5+)
   * Description: Automatically generates a secure random password for LTPA keys and exports it as the `ltpa_keys_password` environment variable. This prevents the LTPA service from failing with error `CWWKS4118E` when no LTPA keys password is configured.
   * Default: `"true"`.
   * Note: If `ltpa_keys_password` is already set, automatic generation is skipped. Set to `"false"` to disable.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ The following container image build variables are now **deprecated**. You should
 Single Sign-On can be optionally configured by adding Liberty server variables in an xml file, by passing environment variables (less secure),
 or by passing Liberty server variables in through the Liberty operator. See [SECURITY.md](SECURITY.md).
 
-
 ## OpenJ9 Shared Class Cache (SCC)
 
 OpenJ9's SCC allows the VM to store Java classes in an optimized form that can be loaded very quickly, JIT compiled code, and profiling data. Deploying an SCC file together with your application can significantly improve start-up time. The SCC can also be shared by multiple VMs, thereby reducing total memory consumption.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ The following container image build variables are now **deprecated**. You should
 Single Sign-On can be optionally configured by adding Liberty server variables in an xml file, by passing environment variables (less secure),
 or by passing Liberty server variables in through the Liberty operator. See [SECURITY.md](SECURITY.md).
 
+The following runtime environment variables control security-related behavior:
+
+* `GENERATE_LTPA_KEYS_PASSWORD` (environment variable, 26.0.0.5+)
+  * Description: Automatically generates a secure random password for LTPA keys and exports it as the `ltpa_keys_password` environment variable. This prevents the LTPA service from failing with error `CWWKS4118E` when no LTPA keys password is configured.
+  * Default: `"true"`.
+  * Note: If `ltpa_keys_password` is already set, automatic generation is skipped. Set to `"false"` to disable.
+
 ## OpenJ9 Shared Class Cache (SCC)
 
 OpenJ9's SCC allows the VM to store Java classes in an optimized form that can be loaded very quickly, JIT compiled code, and profiling data. Deploying an SCC file together with your application can significantly improve start-up time. The SCC can also be shared by multiple VMs, thereby reducing total memory consumption.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ This section describes the optional build variables that can be enabled via the 
   *  XML Snippet Location: [hazelcast-sessioncache.xml](/releases/latest/kernel-slim/helpers/build/configuration_snippets/hazelcast-sessioncache.xml)
 * `VERBOSE`
   *  Description: When set to `true` it outputs the commands and results to stdout from `configure.sh`. Otherwise, default setting is `false` and `configure.sh` is silenced.
+* `GENERATE_LTPA_KEYS_PASSWORD` (environment variable, 26.0.0.5+)
+  * Description: Automatically generates a secure random password for LTPA keys and exports it as the `ltpa_keys_password` environment variable. This prevents the LTPA service from failing with error `CWWKS4118E` when no LTPA keys password is configured.
+  * Default: `"true"`.
+  * Note: If `ltpa_keys_password` is already set, automatic generation is skipped. Set to `"false"` to disable.
 
 ### Deprecated Build Variables
 
@@ -108,12 +112,6 @@ The following container image build variables are now **deprecated**. You should
 Single Sign-On can be optionally configured by adding Liberty server variables in an xml file, by passing environment variables (less secure),
 or by passing Liberty server variables in through the Liberty operator. See [SECURITY.md](SECURITY.md).
 
-The following runtime environment variables control security-related behavior:
-
-* `GENERATE_LTPA_KEYS_PASSWORD` (environment variable, 26.0.0.5+)
-  * Description: Automatically generates a secure random password for LTPA keys and exports it as the `ltpa_keys_password` environment variable. This prevents the LTPA service from failing with error `CWWKS4118E` when no LTPA keys password is configured.
-  * Default: `"true"`.
-  * Note: If `ltpa_keys_password` is already set, automatic generation is skipped. Set to `"false"` to disable.
 
 ## OpenJ9 Shared Class Cache (SCC)
 

--- a/releases/26.0.0.5/full/helpers/runtime/docker-server.sh
+++ b/releases/26.0.0.5/full/helpers/runtime/docker-server.sh
@@ -100,6 +100,12 @@ fi
 
 importKeyCert
 
+
+if [ "${GENERATE_LTPA_KEYS_PASSWORD:-true}" = "true" ] && [ -z "$ltpa_keys_password" ]; then
+  export ltpa_keys_password=$(openssl rand -base64 32 2>/dev/null)
+  echo "Generated ltpa_keys_password for LTPA configuration"
+fi
+
 # Infinispan Session Caching
 if [[ -n "$INFINISPAN_SERVICE_NAME" ]]; then
  echo "INFINISPAN_SERVICE_NAME(original): ${INFINISPAN_SERVICE_NAME}"

--- a/releases/26.0.0.5/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/26.0.0.5/kernel-slim/helpers/runtime/docker-server.sh
@@ -100,6 +100,12 @@ fi
 
 importKeyCert
 
+
+if [ "${GENERATE_LTPA_KEYS_PASSWORD:-true}" = "true" ] && [ -z "$ltpa_keys_password" ]; then
+  export ltpa_keys_password=$(openssl rand -base64 32 2>/dev/null)
+  echo "Generated ltpa_keys_password for LTPA configuration"
+fi
+
 # Infinispan Session Caching
 if [[ -n "$INFINISPAN_SERVICE_NAME" ]]; then
  echo "INFINISPAN_SERVICE_NAME(original): ${INFINISPAN_SERVICE_NAME}"

--- a/releases/latest/full/helpers/runtime/docker-server.sh
+++ b/releases/latest/full/helpers/runtime/docker-server.sh
@@ -100,6 +100,12 @@ fi
 
 importKeyCert
 
+
+if [ "${GENERATE_LTPA_KEYS_PASSWORD:-true}" = "true" ] && [ -z "$ltpa_keys_password" ]; then
+  export ltpa_keys_password=$(openssl rand -base64 32 2>/dev/null)
+  echo "Generated ltpa_keys_password for LTPA configuration"
+fi
+
 # Infinispan Session Caching
 if [[ -n "$INFINISPAN_SERVICE_NAME" ]]; then
  echo "INFINISPAN_SERVICE_NAME(original): ${INFINISPAN_SERVICE_NAME}"

--- a/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
+++ b/releases/latest/kernel-slim/helpers/runtime/docker-server.sh
@@ -100,6 +100,12 @@ fi
 
 importKeyCert
 
+
+if [ "${GENERATE_LTPA_KEYS_PASSWORD:-true}" = "true" ] && [ -z "$ltpa_keys_password" ]; then
+  export ltpa_keys_password=$(openssl rand -base64 32 2>/dev/null)
+  echo "Generated ltpa_keys_password for LTPA configuration"
+fi
+
 # Infinispan Session Caching
 if [[ -n "$INFINISPAN_SERVICE_NAME" ]]; then
  echo "INFINISPAN_SERVICE_NAME(original): ${INFINISPAN_SERVICE_NAME}"


### PR DESCRIPTION
- Creates a random LTPA keys password `ltpa_keys_password` (environment variable) by default unless `GENERATE_LTPA_KEYS_PASSWORD` is set to `false` or the variable is already set. 

For https://github.com/OpenLiberty/ci.docker/issues/718