### PR TITLE
Merge vNext into main to include fix for SCC generation error with IBM Java 8

### DIFF
--- a/releases/25.0.0.12/full/helpers/build/populate_scc.sh
+++ b/releases/25.0.0.12/full/helpers/build/populate_scc.sh
@@ -29,7 +29,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/releases/25.0.0.12/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/25.0.0.12/kernel-slim/helpers/build/populate_scc.sh
@@ -29,7 +29,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/releases/26.0.0.3/full/helpers/build/populate_scc.sh
+++ b/releases/26.0.0.3/full/helpers/build/populate_scc.sh
@@ -29,7 +29,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/releases/26.0.0.3/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/26.0.0.3/kernel-slim/helpers/build/populate_scc.sh
@@ -29,7 +29,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/releases/26.0.0.6/full/helpers/build/populate_scc.sh
+++ b/releases/26.0.0.6/full/helpers/build/populate_scc.sh
@@ -29,7 +29,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/releases/26.0.0.6/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/26.0.0.6/kernel-slim/helpers/build/populate_scc.sh
@@ -29,7 +29,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/releases/26.0.0.8/full/helpers/build/populate_scc.sh
+++ b/releases/26.0.0.8/full/helpers/build/populate_scc.sh
@@ -29,7 +29,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/releases/26.0.0.8/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/26.0.0.8/kernel-slim/helpers/build/populate_scc.sh
@@ -29,7 +29,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/releases/latest/full/helpers/build/populate_scc.sh
+++ b/releases/latest/full/helpers/build/populate_scc.sh
@@ -29,7 +29,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/releases/latest/kernel-slim/helpers/build/populate_scc.sh
+++ b/releases/latest/kernel-slim/helpers/build/populate_scc.sh
@@ -29,7 +29,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"


### PR DESCRIPTION
Merge vNext into main to resolve the SCC generation error with IBM Java 8:
- Disable GCContainerHeuristics option to fix failures with IBM Java 8.0.8.70 (#741)